### PR TITLE
Add settings and about screens with legal, credits, and contact infor…

### DIFF
--- a/app/src/main/java/com/pelotcl/app/MainActivity.kt
+++ b/app/src/main/java/com/pelotcl/app/MainActivity.kt
@@ -12,6 +12,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
@@ -30,6 +32,7 @@ import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -55,8 +58,13 @@ import com.google.android.gms.tasks.CancellationTokenSource
 import com.pelotcl.app.ui.components.LinesBottomSheet
 import com.pelotcl.app.ui.components.SimpleSearchBar
 import com.pelotcl.app.ui.components.StationSearchResult
+import com.pelotcl.app.ui.screens.AboutScreen
+import com.pelotcl.app.ui.screens.ContactScreen
+import com.pelotcl.app.ui.screens.CreditsScreen
 import com.pelotcl.app.ui.screens.ItineraryScreen
+import com.pelotcl.app.ui.screens.LegalScreen
 import com.pelotcl.app.ui.screens.PlanScreen
+import com.pelotcl.app.ui.screens.SettingsScreen
 import com.pelotcl.app.ui.theme.PeloTheme
 import com.pelotcl.app.ui.theme.Red500
 import com.pelotcl.app.ui.viewmodel.TransportViewModel
@@ -113,6 +121,10 @@ private enum class Destination(
 
     companion object {
         val entries: List<Destination> = values().toList()
+        const val ABOUT = "about"
+        const val LEGAL = "legal"
+        const val CREDITS = "credits"
+        const val CONTACT = "contact"
     }
 }
 
@@ -218,6 +230,34 @@ fun NavBar(modifier: Modifier = Modifier) {
         }
     }
 
+    // Gérer la barre de statut selon l'écran actif
+    DisposableEffect(selectedDestination) {
+        val activity = context as? ComponentActivity
+        if (selectedDestination == Destination.PARAMETRES.ordinal) {
+            // Barre de statut avec icônes blanches pour fond noir
+            activity?.enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.dark(
+                    android.graphics.Color.TRANSPARENT
+                ),
+                navigationBarStyle = SystemBarStyle.dark(
+                    android.graphics.Color.TRANSPARENT
+                )
+            )
+        } else {
+            // Barre de statut normale pour les autres écrans
+            activity?.enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.light(
+                    android.graphics.Color.TRANSPARENT,
+                    android.graphics.Color.TRANSPARENT
+                ),
+                navigationBarStyle = SystemBarStyle.dark(
+                    android.graphics.Color.TRANSPARENT
+                )
+            )
+        }
+        onDispose { }
+    }
+
     Box(modifier = modifier) {
         Scaffold(
             modifier = Modifier.fillMaxSize(),
@@ -234,6 +274,15 @@ fun NavBar(modifier: Modifier = Modifier) {
                                 itineraryDestinationStop = null
                                 
                                 if (destination == Destination.LIGNES) {
+                                    // Si on n'est pas sur Plan, naviguer vers Plan d'abord
+                                    if (selectedDestination != Destination.PLAN.ordinal) {
+                                        navController.navigate(Destination.PLAN.route) {
+                                            launchSingleTop = true
+                                            popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                            restoreState = true
+                                        }
+                                        selectedDestination = Destination.PLAN.ordinal
+                                    }
                                     showLinesSheet = true
                                 } else if (selectedDestination != index) {
                                     navController.navigate(destination.route) {
@@ -338,7 +387,11 @@ private fun AppNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination.route,
-        modifier = modifier
+        modifier = modifier,
+        enterTransition = { EnterTransition.None },
+        exitTransition = { ExitTransition.None },
+        popEnterTransition = { EnterTransition.None },
+        popExitTransition = { ExitTransition.None }
     ) {
         composable(Destination.PLAN.route) {
             PlanScreen(
@@ -372,12 +425,48 @@ private fun AppNavHost(
             )
         }
         composable(Destination.PARAMETRES.route) {
-            SimpleScreen(title = "Paramètres")
+            SettingsScreen(
+                onAboutClick = {
+                    navController.navigate(Destination.ABOUT)
+                }
+            )
+        }
+        composable(Destination.ABOUT) {
+            AboutScreen(
+                onBackClick = {
+                    navController.popBackStack()
+                },
+                onLegalClick = {
+                    navController.navigate(Destination.LEGAL)
+                },
+                onCreditsClick = {
+                    navController.navigate(Destination.CREDITS)
+                },
+                onContactClick = {
+                    navController.navigate(Destination.CONTACT)
+                }
+            )
+        }
+        composable(Destination.LEGAL) {
+            LegalScreen(
+                onBackClick = {
+                    navController.popBackStack()
+                }
+            )
+        }
+        composable(Destination.CREDITS) {
+            CreditsScreen(
+                onBackClick = {
+                    navController.popBackStack()
+                }
+            )
+        }
+        composable(Destination.CONTACT) {
+            ContactScreen(
+                onBackClick = {
+                    navController.popBackStack()
+                }
+            )
         }
     }
-}
-
-@Composable
-private fun SimpleScreen(title: String) {
-    Text(text = title)
 }

--- a/app/src/main/java/com/pelotcl/app/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/pelotcl/app/ui/screens/AboutScreen.kt
@@ -1,0 +1,163 @@
+package com.pelotcl.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowRight
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.util.Optional
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(
+    onBackClick: () -> Unit,
+    onLegalClick: () -> Unit = {},
+    onCreditsClick: () -> Unit = {},
+    onContactClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "À propos",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour",
+                            tint = Color.White,
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black
+                )
+            )
+        },
+        containerColor = Color.Black
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            // App version
+            AboutMenuItem(
+                title = "Version de l'application",
+                subtitle = "0.0.0",
+                onClick = {}
+            )
+
+            HorizontalDivider()
+
+            // Legal mentions / Terms of use
+            AboutMenuItem(
+                title = "Mentions légales / CGU",
+                onClick = onLegalClick
+            )
+
+            HorizontalDivider()
+
+            // Credits
+            AboutMenuItem(
+                title = "Crédits",
+                onClick = onCreditsClick
+            )
+
+            HorizontalDivider()
+
+            // Contact / Signal a bug
+            AboutMenuItem(
+                title = "Nous contacter / Signaler un bug",
+                onClick = onContactClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun AboutMenuItem(
+    title: String,
+    subtitle: String = "",
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val cardModifier = modifier
+        .fillMaxWidth()
+        .padding(vertical = 8.dp)
+        .clickable(onClick = onClick)
+
+    Card(
+        modifier = cardModifier,
+        colors = CardDefaults.cardColors(
+            containerColor = Color.Black
+        )
+    ) {
+        Row {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = title,
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                if (subtitle != "") {
+                    Text(
+                        text = subtitle,
+                        color = Color.Gray,
+                        fontSize = 14.sp,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+            if (subtitle == "") {
+                Icon(
+                    imageVector = Icons.Filled.ChevronRight,
+                    contentDescription = "Next Arrow Icon",
+                    tint = Color.White,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pelotcl/app/ui/screens/ContactScreen.kt
+++ b/app/src/main/java/com/pelotcl/app/ui/screens/ContactScreen.kt
@@ -1,0 +1,126 @@
+package com.pelotcl.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val uriHandler = LocalUriHandler.current
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Nous contacter / Signaler un bug",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour",
+                            tint = Color.White
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black
+                )
+            )
+        },
+        containerColor = Color.Black
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "Une question ? Un problème ?",
+                color = Color.White,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "N'hésitez pas à nous contacter pour toute question, suggestion ou pour signaler un bug.",
+                color = Color.White,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Signaler un bug",
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "Pour signaler un bug, merci de nous envoyer un message via la page contact" +
+                        " de notre site web [dotshell.eu].",
+                color = Color.White,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+
+            Button(
+                onClick = { uriHandler.openUri("https://www.dotshell.eu/contact") },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF3B82F6)
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text(
+                    text = "Nous contacter",
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pelotcl/app/ui/screens/CreditsScreen.kt
+++ b/app/src/main/java/com/pelotcl/app/ui/screens/CreditsScreen.kt
@@ -1,0 +1,215 @@
+package com.pelotcl.app.ui.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreditsScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Crédits",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour",
+                            tint = Color.White
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black
+                )
+            )
+        },
+        containerColor = Color.Black
+    ) { paddingValues ->
+        val uriHandler = LocalUriHandler.current
+        
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "Données de transport",
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Text(
+                text = "Les données de transport utilisées dans l'application proviennent " +
+                        "exclusivement du site de la métropole de Lyon [data.grandlyon.com]. Les " +
+                        "tracés géographiques des lignes de bus (incluant Chrono, Pleine Lune, " +
+                        "Bus relais, Gare Express, Navette, Soyeuse, Zone industrielle et Junior " +
+                        "Direct), tramway, Rhône Express, trambus, métropolitain, funiculaire et" +
+                        "Navigone sont téléchargés en direct depuis l'API publique de la " +
+                        "métropole de Lyon. Il en va de même pour les positions géographiques des " +
+                        "arrêts du réseau qui sont téléchargées en direct depuis l'API. Quant " +
+                        "aux noms des arrêts et des lignes, ainsi qu'aux horaires, l'application " +
+                        "utilise comme source le fichier GTFS fourni par la métropole de Lyon sur" +
+                        "son site. Les icônes des lignes proviennent également de ce même site.",
+                color = Color.White,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            
+            ClickableLink(
+                label = "data.grandlyon.com",
+                url = "https://data.grandlyon.com",
+                uriHandler = uriHandler
+            )
+            
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = "Cartographie",
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 8.dp, top = 8.dp)
+            )
+
+            Text(
+                text = "Les données de cartographie sont fournies par MapLibre [maplibre.org] et " +
+                        "OpenStreetMaps [openstreetmap.org]. Le fond de carte est fourni par " +
+                        "OpenMapTiles [openmaptiles.org]. L'application utilise le thème \"Light\" " +
+                        "de Map Tiler [maptiler.com].",
+                color = Color.White,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            
+            Column(modifier = Modifier.padding(bottom = 16.dp)) {
+                ClickableLink(
+                    label = "maplibre.org",
+                    url = "https://maplibre.org",
+                    uriHandler = uriHandler
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                ClickableLink(
+                    label = "openstreetmap.org",
+                    url = "https://www.openstreetmap.org",
+                    uriHandler = uriHandler
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                ClickableLink(
+                    label = "openmaptiles.org",
+                    url = "https://openmaptiles.org",
+                    uriHandler = uriHandler
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                ClickableLink(
+                    label = "maptiler.com",
+                    url = "https://www.maptiler.com",
+                    uriHandler = uriHandler
+                )
+            }
+
+            Text(
+                text = "Développement",
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 8.dp, top = 8.dp)
+            )
+
+            Text(
+                text = "L'application est développée de manière indépendante par Dotshell [dotshell.eu] " +
+                        "sous license GPL-3.0. Pelo n'est pas affilié aux TCL ou à la SYTRAL. Les " +
+                        "données utilisées sont totalement publiques et accessibles à tous. Il est " +
+                        "possible à n'importe qui d'aider au développement de l'application sur " +
+                        "GitHub [github.com/dotshell-org/pelo-android].",
+                color = Color.White,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            ClickableLink(
+                label = "dotshell.eu",
+                url = "https://www.dotshell.eu",
+                uriHandler = uriHandler
+            )
+            ClickableLink(
+                label = "github.com/dotshell-org/pelo-android",
+                url = "https://github.com/dotshell-org/pelo-android",
+                uriHandler = uriHandler
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+        }
+    }
+}
+
+@Composable
+private fun ClickableLink(
+    label: String,
+    url: String,
+    uriHandler: androidx.compose.ui.platform.UriHandler,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.clickable { uriHandler.openUri(url) }
+    ) {
+        Text(
+            text = label,
+            color = Color(0xFF3B82F6),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Icon(
+            imageVector = Icons.Filled.OpenInNew,
+            contentDescription = "Ouvrir",
+            tint = Color(0xFF3B82F6),
+            modifier = Modifier
+                .padding(top = 2.dp)
+                .width(14.dp)
+                .height(14.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/pelotcl/app/ui/screens/LegalScreen.kt
+++ b/app/src/main/java/com/pelotcl/app/ui/screens/LegalScreen.kt
@@ -1,0 +1,73 @@
+package com.pelotcl.app.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LegalScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "Mentions légales / CGU",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Retour",
+                            tint = Color.White
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black
+                )
+            )
+        },
+        containerColor = Color.Black
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "La version que vous utilisez actuellement est une alpha non destinée à l'utilisation. Les CGU ne sont pas encore écrites.",
+                color = Color.White,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pelotcl/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/pelotcl/app/ui/screens/SettingsScreen.kt
@@ -1,0 +1,72 @@
+package com.pelotcl.app.ui.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SettingsScreen(
+    onAboutClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            // Logo Pelo
+            Image(
+                painter = painterResource(id = com.pelotcl.app.R.drawable.ic_launcher_foreground),
+                contentDescription = "Logo Pelo",
+                modifier = Modifier
+                    .size(200.dp)
+                    .padding(bottom = 48.dp)
+            )
+
+            // Bouton À propos
+            Button(
+                onClick = onAboutClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF2C2C2C)
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Text(
+                    text = "À propos",
+                    color = Color.White,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several new informational screens (About, Legal, Credits, Contact) and enhances navigation and UI behavior in the main activity. The most significant changes include adding new composable screens, updating navigation logic, and improving system bar handling for a more polished user experience.

**New informational screens:**

* Added `AboutScreen`, `LegalScreen`, `CreditsScreen`, and `ContactScreen` composables to provide users with app information, legal mentions, credits, and contact/bug report options. (`app/src/main/java/com/pelotcl/app/ui/screens/AboutScreen.kt` [[1]](diffhunk://#diff-d290ffb64d46e64176eca6727a0b231666aa5fe6c3d90903b36becfdeff655edR1-R163) `app/src/main/java/com/pelotcl/app/ui/screens/ContactScreen.kt` [[2]](diffhunk://#diff-80dd057b1afe3664f746330b119ad3242a85acd520b4a78e070cd4897981eac6R1-R126) `app/src/main/java/com/pelotcl/app/MainActivity.kt` [[3]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR61-R67) [[4]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbL375-L382)

**Navigation and routing improvements:**

* Extended the navigation graph in `MainActivity.kt` to include routes for the new informational screens, and updated the settings screen to navigate to the About screen. (`app/src/main/java/com/pelotcl/app/MainActivity.kt` [[1]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR124-R127) [[2]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbL375-L382)
* Modified the navigation logic for the lines bottom sheet to ensure the user is navigated to the Plan screen before showing the sheet if not already there. (`app/src/main/java/com/pelotcl/app/MainActivity.kt` [app/src/main/java/com/pelotcl/app/MainActivity.ktR277-R285](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR277-R285))

**User interface and system bar enhancements:**

* Added logic to dynamically adjust the status bar and navigation bar styles based on the currently selected screen, ensuring proper contrast and appearance (e.g., white icons on black for the settings screen). (`app/src/main/java/com/pelotcl/app/MainActivity.kt` [app/src/main/java/com/pelotcl/app/MainActivity.ktR233-R260](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR233-R260))
* Disabled default enter/exit transitions for navigation to provide instant screen changes without animation. (`app/src/main/java/com/pelotcl/app/MainActivity.kt` [app/src/main/java/com/pelotcl/app/MainActivity.ktL341-R394](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbL341-R394))

**Dependency and import updates:**

* Imported new screen composables and necessary Compose animation and lifecycle dependencies to support the new features. (`app/src/main/java/com/pelotcl/app/MainActivity.kt` [[1]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR15-R16) [[2]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR35) [[3]](diffhunk://#diff-83efe4a3beadf84d8e652c8fe31c907a4b233311e5ec22968f95d1cf20b410dbR61-R67)

*   Implement `SettingsScreen` as a main navigation destination with a link to the "About" section.
*   Create `AboutScreen` featuring version information and links to legal mentions, credits, and contact pages.
*   Add `LegalScreen` for terms of use and `CreditsScreen` to attribute data sources (Grand Lyon, MapLibre, OpenStreetMap).
*   Add `ContactScreen` with links to external support and bug reporting via the project website.
*   Update `MainActivity` navigation logic to handle new routes and implement status bar color switching for dark-themed screens.
*   Fix navigation behavior to ensure the map view is active when opening the lines bottom sheet.