### PR TITLE
Optimize performance and caching: introduce reusable caches for asset…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,10 @@
       "Bash(powershell -Command:*)",
       "Bash(cmd /c \"gradlew.bat assembleDebug 2>&1\")",
       "Bash(cmd.exe /c \"gradlew.bat assembleDebug 2>&1\")",
-      "WebFetch(domain:medium.com)"
+      "WebFetch(domain:medium.com)",
+      "Bash(./gradlew compileReleaseKotlin)",
+      "Bash(xxd)",
+      "Bash(./gradlew compileDebugKotlin)"
     ]
   }
 }

--- a/app/src/main/java/com/pelotcl/app/generic/data/network/RetrofitInstance.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/data/network/RetrofitInstance.kt
@@ -109,4 +109,12 @@ object RetrofitInstance {
         }
     }
 
+    /**
+     * Get the shared OkHttpClient with cache and connection pool.
+     * Useful for creating Retrofit instances with different base URLs
+     * while sharing the HTTP cache and connection pool.
+     * Returns null if not yet initialized - callers should fallback gracefully.
+     */
+    fun getSharedClient(): OkHttpClient? = okHttpClient
+
 }

--- a/app/src/main/java/com/pelotcl/app/generic/data/repository/itinerary/RaptorRepository.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/data/repository/itinerary/RaptorRepository.kt
@@ -70,6 +70,13 @@ class RaptorRepository private constructor(private val context: Context) {
     // Performance: Reusable StringBuilder for cache key building (ThreadLocal for thread safety)
     private val cacheKeyBuilder = ThreadLocal.withInitial { StringBuilder(64) }
 
+    // Performance: Cached result of checkAssetsAvailable() to avoid repeated file I/O
+    @Volatile
+    private var cachedAssetsAvailable: Boolean? = null
+
+    // Performance: Pre-computed list of stops with coords to avoid repeated .map{} allocations
+    private var cachedStopsWithCoords: List<RaptorStopWithCoords> = emptyList()
+
     // Period IDs matching asset file naming
     companion object {
         private const val TAG = "RaptorRepository"
@@ -204,6 +211,17 @@ class RaptorRepository private constructor(private val context: Context) {
 
                 // Build performance indexes
                 buildStopIndexes()
+
+                // Pre-compute cached values to avoid repeated allocations
+                cachedAssetsAvailable = true // assets verified above
+                cachedStopsWithCoords = stopsCache.map { stop ->
+                    RaptorStopWithCoords(
+                        id = stop.id,
+                        name = stop.name,
+                        lat = stop.lat,
+                        lon = stop.lon
+                    )
+                }
 
                 isInitialized = true
 
@@ -510,7 +528,8 @@ class RaptorRepository private constructor(private val context: Context) {
      * Useful for coordinate-based matching with WFS stops.
      */
     fun getAllStopsWithCoords(): List<RaptorStopWithCoords> {
-        return stopsCache.map { stop ->
+        if (cachedStopsWithCoords.isNotEmpty()) return cachedStopsWithCoords
+        val result = stopsCache.map { stop ->
             RaptorStopWithCoords(
                 id = stop.id,
                 name = stop.name,
@@ -518,6 +537,8 @@ class RaptorRepository private constructor(private val context: Context) {
                 lon = stop.lon
             )
         }
+        cachedStopsWithCoords = result
+        return result
     }
 
     /**
@@ -525,7 +546,8 @@ class RaptorRepository private constructor(private val context: Context) {
      * @return true if all assets are present, false otherwise
      */
     fun checkAssetsAvailable(): Boolean {
-        return runCatching {
+        cachedAssetsAvailable?.let { return it }
+        val result = runCatching {
             val requiredAssets = listOf(
                 "holidays.json",
                 "stops_saturday.bin", "routes_saturday.bin",
@@ -538,6 +560,8 @@ class RaptorRepository private constructor(private val context: Context) {
                 runCatching { context.assets.open(assetName).close() }.isSuccess
             }
         }.getOrDefault(false)
+        cachedAssetsAvailable = result
+        return result
     }
 
     /**

--- a/app/src/main/java/com/pelotcl/app/generic/data/repository/offline/SchedulesRepository.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/data/repository/offline/SchedulesRepository.kt
@@ -42,31 +42,17 @@ class SchedulesRepository private constructor(context: Context) {
         val cacheKey = query.trim().lowercase()
         searchCache.get(cacheKey)?.let { return it }
 
+        val assetsAvailable = raptorRepository.checkAssetsAvailable()
         val results = raptorRepository.searchStopsByName(query)
             .map { stop ->
                 val desserte = raptorRepository.getDesserteForStop(stop.name).orEmpty()
                 val lines = if (desserte.isEmpty() || desserte.equals("UNKNOWN", ignoreCase = true)) {
-                    // If desserte is empty or UNKNOWN, try to enrich from Raptor
-                    val assetsAvailable = raptorRepository.checkAssetsAvailable()
                     if (!assetsAvailable) {
                         Log.w("SchedulesRepository", "Stop ${stop.name} has no desserte data - Raptor assets may be missing")
-                        // Return empty list but don't filter out the stop completely
                         emptyList()
                     } else {
-                        // Try to get desserte from Raptor even if WFS says UNKNOWN
-                        val raptorDesserte = raptorRepository.getDesserteForStop(stop.name).orEmpty()
-                        if (raptorDesserte.isNotBlank() && raptorDesserte != "UNKNOWN") {
-                            raptorDesserte.split(',')
-                                .mapNotNull { part ->
-                                    val token = part.trim()
-                                    if (token.isEmpty()) null else token.substringBefore(':').trim()
-                                }
-                                .filter { it.isNotEmpty() }
-                                .distinct()
-                        } else {
-                            // No desserte available from either source
-                            emptyList()
-                        }
+                        // desserte already fetched above - reuse it (no second call needed)
+                        emptyList()
                     }
                 } else {
                     desserte.split(',')

--- a/app/src/main/java/com/pelotcl/app/generic/ui/components/favorites/FavoritesBar.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/ui/components/favorites/FavoritesBar.kt
@@ -85,8 +85,10 @@ fun FavoritesBar(
 
         val createButtonWidth =
             remember(density, textMeasurer) { estimateButtonWidth("Creer un favori") }
-        val favoritesTotalWidth = favorites.fold(0.dp) { acc, favorite ->
-            acc + estimateButtonWidth(favorite.name)
+        val favoritesTotalWidth = remember(favorites, density, textMeasurer) {
+            favorites.fold(0.dp) { acc, favorite ->
+                acc + estimateButtonWidth(favorite.name)
+            }
         }
         val totalSpacing = (favorites.size * interItemSpacing.value).dp
         val estimatedTotalContentWidth = createButtonWidth + favoritesTotalWidth + totalSpacing

--- a/app/src/main/java/com/pelotcl/app/generic/ui/components/search/SimpleSearchBar.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/ui/components/search/SimpleSearchBar.kt
@@ -19,12 +19,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Directions
@@ -371,10 +372,10 @@ fun SimpleSearchBar(
                 dividerColor = Color.Transparent
             )
         ) {
-            val scrollState = rememberScrollState()
+            val lazyListState = rememberLazyListState()
 
-            LaunchedEffect(scrollState) {
-                snapshotFlow { scrollState.isScrollInProgress }
+            LaunchedEffect(lazyListState) {
+                snapshotFlow { lazyListState.isScrollInProgress }
                     .collect { isScrolling ->
                         if (isScrolling) {
                             keyboardHiddenByScroll = true
@@ -383,8 +384,8 @@ fun SimpleSearchBar(
                     }
             }
 
-            Column(
-                Modifier
+            LazyColumn(
+                modifier = Modifier
                     .padding(top = 12.dp, bottom = 28.dp)
                     .pointerInput(Unit) {
                         awaitPointerEventScope {
@@ -394,37 +395,37 @@ fun SimpleSearchBar(
                             }
                         }
                     }
-                    .verticalScroll(scrollState)
                     .clickable(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() }
-                    ) {}
+                    ) {},
+                state = lazyListState
             ) {
-                if (queryText.isEmpty()) {
-                    if (showHistory && searchHistory.isNotEmpty()) {
+                if (queryText.isEmpty() && showHistory && searchHistory.isNotEmpty()) {
+                    item(key = "history_header") {
                         SectionHeader(icon = Icons.Default.History, text = "Recherches récentes")
-                        searchHistory.forEach { historyItem ->
-                            HistoryListItem(
-                                historyItem = historyItem,
-                                showRemove = true,
-                                onClick = {
-                                    onHistoryItemClick(historyItem)
-                                    setQueryText("")
-                                    setExpandedState(false)
-                                },
-                                onOptionsClick = {
-                                    setQueryText("")
-                                    setExpandedState(false)
-                                    keyboardController?.hide()
-                                    onHistoryItemOptionsClick(historyItem)
-                                },
-                                onRemoveClick = { onHistoryItemRemove(historyItem) }
-                            )
-                        }
+                    }
+                    items(searchHistory, key = { "history_${it.query}_${it.type}" }) { historyItem ->
+                        HistoryListItem(
+                            historyItem = historyItem,
+                            showRemove = true,
+                            onClick = {
+                                onHistoryItemClick(historyItem)
+                                setQueryText("")
+                                setExpandedState(false)
+                            },
+                            onOptionsClick = {
+                                setQueryText("")
+                                setExpandedState(false)
+                                keyboardController?.hide()
+                                onHistoryItemOptionsClick(historyItem)
+                            },
+                            onRemoveClick = { onHistoryItemRemove(historyItem) }
+                        )
                     }
                 }
 
-                combinedResults.forEach { unifiedResult ->
+                items(combinedResults, key = { it.sortKey }) { unifiedResult ->
                     when (unifiedResult) {
                         is UnifiedSearchResult.Line -> {
                             LineSearchResultItem(
@@ -466,32 +467,36 @@ fun SimpleSearchBar(
                     }
                 }
 
-                Spacer(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(60.dp)
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() }
-                        ) {
-                            setExpandedState(false)
-                            keyboardController?.hide()
-                        }
-                )
+                item(key = "bottom_spacer") {
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(60.dp)
+                            .clickable(
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() }
+                            ) {
+                                setExpandedState(false)
+                                keyboardController?.hide()
+                            }
+                    )
+                }
 
                 if (showNoResults) {
-                    ListItem(
-                        headlineContent = {
-                            Text(
-                                "Aucun résultat",
-                                color = SecondaryColor.copy(alpha = 0.6f),
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        },
-                        colors = ListItemDefaults.colors(containerColor = PrimaryColor),
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                    item(key = "no_results") {
+                        ListItem(
+                            headlineContent = {
+                                Text(
+                                    "Aucun résultat",
+                                    color = SecondaryColor.copy(alpha = 0.6f),
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            },
+                            colors = ListItemDefaults.colors(containerColor = PrimaryColor),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/pelotcl/app/generic/ui/screens/plan/InlineItinerarySheetContent.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/ui/screens/plan/InlineItinerarySheetContent.kt
@@ -290,7 +290,7 @@ fun InlineItinerarySheetContent(
                         .weight(1f),
                     contentPadding = PaddingValues(bottom = 24.dp)
                 ) {
-                    items(journeys) { journey ->
+                    items(journeys, key = { "${it.departureTime}_${it.arrivalTime}_${it.legs.size}" }) { journey ->
                         CompactJourneyCard(
                             journey = journey,
                             onClick = { selectedJourney = journey },

--- a/app/src/main/java/com/pelotcl/app/generic/ui/viewmodel/TransportViewModel.kt
+++ b/app/src/main/java/com/pelotcl/app/generic/ui/viewmodel/TransportViewModel.kt
@@ -43,6 +43,12 @@ import java.io.File
  */
 class TransportViewModel(private val context: Context) : ViewModel() {
 
+    companion object {
+        private const val TAG = "TransportViewModel"
+        // Set to false for production builds to skip string formatting overhead in hot paths
+        private const val DEBUG_LOGGING = false
+    }
+
     private val transportApi: TransportApi = TransportServiceProvider.getTransportApi()
     private val vehiclePositionsService = TransportServiceProvider.getVehiclePositionsService()
     private val lineRules = TransportServiceProvider.getTransportLineRules()
@@ -56,6 +62,8 @@ class TransportViewModel(private val context: Context) : ViewModel() {
     private val favoritesRepository = FavoritesRepository(context)
     val raptorRepository = RaptorRepository.getInstance(context)
     val offlineDataManager = OfflineDataManager(transportApi, context)
+    private val transportCache by lazy { com.pelotcl.app.specific.data.cache.TransportCacheImpl(context) }
+    private val offlineRepository by lazy { com.pelotcl.app.generic.data.offline.OfflineRepository(context) }
     private val _linesState = MutableStateFlow<TransportLinesState>(TransportLinesState.Loading)
 
     // Compatibilité avec PlanScreen.kt qui utilise TransportLinesUiState
@@ -156,7 +164,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                     _uiState.value = TransportLinesUiState.Success(lines.features.orEmpty())
                     
                     // Save lines to cache for future use
-                    val cache = com.pelotcl.app.specific.data.cache.TransportCacheImpl(context)
+                    val cache = transportCache
                     val metroLines = lines.features.filter { 
                         it.properties.transportType == "METRO" || 
                         it.properties.transportType == "FUNICULAR"
@@ -188,20 +196,19 @@ class TransportViewModel(private val context: Context) : ViewModel() {
     fun loadStops() {
         viewModelScope.launch {
             _stopsUiState.value = TransportStopsUiState.Loading
-            val offlineRepository = com.pelotcl.app.generic.data.offline.OfflineRepository(context)
-            val cache = com.pelotcl.app.specific.data.cache.TransportCacheImpl(context)
+            val cache = transportCache
 
             // Try to load from offline cache first
             val offlineStops = runCatching {
                 withContext(Dispatchers.IO) { offlineRepository.loadStops() }
             }.getOrNull().orEmpty()
 
-            Log.d("TransportViewModel", "Loaded ${offlineStops.size} stops from offline cache")
+            if (DEBUG_LOGGING) Log.d(TAG, "Loaded ${offlineStops.size} stops from offline cache")
             if (offlineStops.isNotEmpty()) {
                 val sampleSize = minOf(10, offlineStops.size)
                 val emptyDesserteCount = offlineStops.take(sampleSize).count { it.properties.desserte.isBlank() }
                 val unknownCount = offlineStops.take(sampleSize).count { it.properties.desserte.equals("UNKNOWN", ignoreCase = true) }
-                Log.d("TransportViewModel", "Offline cache analysis (sample=$sampleSize): ${emptyDesserteCount} empty, ${unknownCount} UNKNOWN")
+                if (DEBUG_LOGGING) Log.d(TAG, "Offline cache analysis (sample=$sampleSize): ${emptyDesserteCount} empty, ${unknownCount} UNKNOWN")
                 
                 // If most stops have empty desserte, force refresh from WFS
                 if (emptyDesserteCount > sampleSize * 0.8) {
@@ -210,7 +217,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                     withContext(Dispatchers.IO) {
                         try {
                             File(context.filesDir, "offline_data/stops.json.gz").delete()
-                            Log.d("TransportViewModel", "Cleared stale stops cache")
+                            if (DEBUG_LOGGING) Log.d(TAG, "Cleared stale stops cache")
                         } catch (e: Exception) {
                             Log.e("TransportViewModel", "Failed to clear cache: ${e.message}")
                         }
@@ -225,21 +232,21 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                 withContext(Dispatchers.IO) { cache.getStops() }
             }.getOrNull().orEmpty()
             
-            Log.d("TransportViewModel", "Loaded ${cachedStops.size} stops from TransportCache")
+            if (DEBUG_LOGGING) Log.d(TAG, "Loaded ${cachedStops.size} stops from TransportCache")
             
             // Determine base stops with clear priority: offline > cache > WFS
             val baseStops: List<StopFeature> = when {
                 offlineStops.isNotEmpty() -> {
-                    Log.d("TransportViewModel", "Using offline cache (${offlineStops.size} stops)")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Using offline cache (${offlineStops.size} stops)")
                     offlineStops
                 }
                 cachedStops.isNotEmpty() -> {
-                    Log.d("TransportViewModel", "Using TransportCache (${cachedStops.size} stops)")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Using TransportCache (${cachedStops.size} stops)")
                     cachedStops
                 }
                 else -> {
                     // Both caches empty - load from WFS API
-                    Log.d("TransportViewModel", "Both offline cache and TransportCache are empty, loading from WFS API")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Both offline cache and TransportCache are empty, loading from WFS API")
                     val wfsResult = runCatching {
                         withContext(Dispatchers.IO) { transportApi.getTransportStops() }
                     }
@@ -258,7 +265,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                         )
                         return@launch
                     }
-                    Log.d("TransportViewModel", "WFS API returned ${features.size} stop features")
+                    if (DEBUG_LOGGING) Log.d(TAG, "WFS API returned ${features.size} stop features")
                     features
                 }
             }
@@ -294,15 +301,16 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                 val ratioNonBlank = nonBlankCount.toDouble() / sampleSize.toDouble()
                 val strongStopCount = sampleStops.count { it.properties.desserte.isNotBlank() && hasStrongToken(it.properties.desserte) }
                 
-                // Debug logging to understand desserte data quality
                 val unknownCount = sampleStops.count { it.properties.desserte.equals("UNKNOWN", ignoreCase = true) }
                 val emptyCount = sampleStops.count { it.properties.desserte.isBlank() }
-                
-                Log.d("TransportViewModel", "Stop desserte analysis (sample=$sampleSize):")
-                Log.d("TransportViewModel", "  Non-blank: $nonBlankCount (${ratioNonBlank * 100}%)")
-                Log.d("TransportViewModel", "  Strong stops: $strongStopCount")
-                Log.d("TransportViewModel", "  UNKNOWN: $unknownCount")
-                Log.d("TransportViewModel", "  Empty: $emptyCount")
+
+                if (DEBUG_LOGGING) {
+                    Log.d(TAG, "Stop desserte analysis (sample=$sampleSize):")
+                    Log.d(TAG, "  Non-blank: $nonBlankCount (${ratioNonBlank * 100}%)")
+                    Log.d(TAG, "  Strong stops: $strongStopCount")
+                    Log.d(TAG, "  UNKNOWN: $unknownCount")
+                    Log.d(TAG, "  Empty: $emptyCount")
+                }
                 
                 // Enrichment conditions:
                 // 1. Original condition: very few stops have desserte (legacy case)
@@ -320,7 +328,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                     val desserteCache = HashMap<String, String>(512)
                     val stopsNeedingEnrichment = baseStops.filter { it.properties.desserte.isBlank() }
                     
-                    Log.d("TransportViewModel", "Enriching ${stopsNeedingEnrichment.size} stops that have empty desserte")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Enriching ${stopsNeedingEnrichment.size} stops that have empty desserte")
                     
                     val enriched = stopsNeedingEnrichment.mapNotNull { stop ->
                         val name = stop.properties.nom
@@ -330,7 +338,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                             val desserte = desserteCache.getOrPut(name) {
                                 schedulesRepository.getDesserteForStop(name).orEmpty()
                             }
-                            Log.d("TransportViewModel", "Enriching stop '$name': WFS desserte='' -> Raptor desserte='$desserte'")
+                            if (DEBUG_LOGGING) Log.d(TAG, "Enriching stop '$name': WFS desserte='' -> Raptor desserte='$desserte'")
                             if (desserte.isBlank()) {
                                 null // Skip stops with no desserte from Raptor
                             } else {
@@ -339,7 +347,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                         }
                     }
                     
-                    Log.d("TransportViewModel", "Successfully enriched ${enriched.size} stops, ${stopsNeedingEnrichment.size - enriched.size} stops have no Raptor data")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Successfully enriched ${enriched.size} stops, ${stopsNeedingEnrichment.size - enriched.size} stops have no Raptor data")
                     
                     // Merge enriched stops back with original stops (keep original if not enriched)
                     val stopMap = baseStops.associateBy { it.properties.nom }.toMutableMap()
@@ -353,20 +361,25 @@ class TransportViewModel(private val context: Context) : ViewModel() {
 
             // Enrich stop names from Raptor/GTFS by matching coordinates
             val stopsWithNames = withContext(Dispatchers.Default) {
-                val stopsNeedingNameEnrichment = enrichedStops.filter { 
-                    it.properties.nom.startsWith("Arret ") || 
+                val stopsNeedingNameEnrichment = enrichedStops.filter {
+                    it.properties.nom.startsWith("Arret ") ||
                     it.properties.nom.contains("Arrondissement")
                 }
-                
+
                 if (stopsNeedingNameEnrichment.isNotEmpty()) {
-                    // Get all Raptor stops with their coordinates for matching
-                    val allRaptorStops = raptorRepository.getAllStopNamesById()
-                    Log.d("TransportViewModel", "Raptor has ${allRaptorStops.size} stops")
-                    
-                    // Build a list of (lat, lon, name) for coordinate matching
                     val raptorStopsWithCoords = raptorRepository.getAllStopsWithCoords()
-                    Log.d("TransportViewModel", "Raptor stops with coords: ${raptorStopsWithCoords.size}")
-                    
+
+                    // Build spatial hash grid for O(1) nearest-neighbor lookup
+                    // Key = (latBucket, lonBucket) truncated to ~100m cells
+                    val gridCellSize = 0.001 // ~100m in degrees
+                    val spatialGrid = HashMap<Long, MutableList<com.pelotcl.app.generic.data.repository.itinerary.RaptorStopWithCoords>>()
+                    for (raptorStop in raptorStopsWithCoords) {
+                        val latBucket = (raptorStop.lat / gridCellSize).toLong()
+                        val lonBucket = (raptorStop.lon / gridCellSize).toLong()
+                        val key = latBucket * 1_000_000L + lonBucket
+                        spatialGrid.getOrPut(key) { mutableListOf() }.add(raptorStop)
+                    }
+
                     var enrichedCount = 0
                     val result = enrichedStops.map { stop ->
                         if (stop.properties.nom.startsWith("Arret ") || stop.properties.nom.contains("Arrondissement")) {
@@ -374,26 +387,32 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                             if (coords.size >= 2) {
                                 val wfsLon = coords[0]
                                 val wfsLat = coords[1]
-                                
-                                // Find closest Raptor stop by coordinates
-                                val closestStop = raptorStopsWithCoords.minByOrNull { raptorStop ->
-                                    val dLat = wfsLat - raptorStop.lat
-                                    val dLon = wfsLon - raptorStop.lon
-                                    dLat * dLat + dLon * dLon
-                                }
-                                
-                                if (closestStop != null) {
-                                    val distance = kotlin.math.sqrt(
-                                        (wfsLat - closestStop.lat).let { it * it } +
-                                        (wfsLon - closestStop.lon).let { it * it }
-                                    )
-                                    // Only use match if within ~50 meters (rough threshold)
-                                    if (distance < 0.0005) { // ~50m in degrees
-                                        enrichedCount++
-                                        stop.copy(properties = stop.properties.copy(nom = closestStop.name))
-                                    } else {
-                                        stop
+                                val latBucket = (wfsLat / gridCellSize).toLong()
+                                val lonBucket = (wfsLon / gridCellSize).toLong()
+
+                                // Search current cell + 8 neighbors for closest stop
+                                var bestStop: com.pelotcl.app.generic.data.repository.itinerary.RaptorStopWithCoords? = null
+                                var bestDistSq = Double.MAX_VALUE
+                                for (dLat in -1L..1L) {
+                                    for (dLon in -1L..1L) {
+                                        val key = (latBucket + dLat) * 1_000_000L + (lonBucket + dLon)
+                                        spatialGrid[key]?.forEach { raptorStop ->
+                                            val latDiff = wfsLat - raptorStop.lat
+                                            val lonDiff = wfsLon - raptorStop.lon
+                                            val distSq = latDiff * latDiff + lonDiff * lonDiff
+                                            if (distSq < bestDistSq) {
+                                                bestDistSq = distSq
+                                                bestStop = raptorStop
+                                            }
+                                        }
                                     }
+                                }
+
+                                // Only use match if within ~50 meters (0.0005 degrees)
+                                val matched = bestStop
+                                if (matched != null && bestDistSq < 0.0005 * 0.0005) {
+                                    enrichedCount++
+                                    stop.copy(properties = stop.properties.copy(nom = matched.name))
                                 } else {
                                     stop
                                 }
@@ -404,7 +423,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                             stop
                         }
                     }
-                    Log.d("TransportViewModel", "Enriched $enrichedCount stop names by coordinates")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Enriched $enrichedCount stop names by coordinates")
                     result
                 } else {
                     enrichedStops
@@ -423,13 +442,13 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                 withContext(Dispatchers.IO) {
                     try {
                         offlineRepository.saveStops(stopsWithNames)
-                        Log.d("TransportViewModel", "Saved ${stopsWithNames.size} stops to offline storage")
+                        if (DEBUG_LOGGING) Log.d(TAG, "Saved ${stopsWithNames.size} stops to offline storage")
                     } catch (e: Exception) {
                         Log.e("TransportViewModel", "Failed to save to offline storage: ${e.message}", e)
                     }
                     try {
                         cache.saveStops(stopsWithNames)
-                        Log.d("TransportViewModel", "Saved ${stopsWithNames.size} stops to TransportCache")
+                        if (DEBUG_LOGGING) Log.d(TAG, "Saved ${stopsWithNames.size} stops to TransportCache")
                     } catch (e: Exception) {
                         Log.e("TransportViewModel", "Failed to save to TransportCache: ${e.message}", e)
                     }
@@ -474,7 +493,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
     fun getConnectionsForStop(stopName: String, lineName: String): Flow<List<LineSearchResult>> {
         return flow {
             val rawDesserte = schedulesRepository.getDesserteForStop(stopName)
-            Log.d("TransportViewModel", "getConnectionsForStop($stopName): raw desserte = '$rawDesserte'")
+            if (DEBUG_LOGGING) Log.d(TAG, "getConnectionsForStop($stopName): raw desserte = '$rawDesserte'")
             val lines = rawDesserte.orEmpty()
                 .split(",")
                 .mapNotNull { token ->
@@ -482,14 +501,15 @@ class TransportViewModel(private val context: Context) : ViewModel() {
                     line.takeIf { it.isNotEmpty() && !it.equals(lineName, ignoreCase = true) }
                 }
                 .distinctBy { it.uppercase() }
-            Log.d("TransportViewModel", "getConnectionsForStop($stopName): parsed ${lines.size} lines: $lines")
+            if (DEBUG_LOGGING) Log.d(TAG, "getConnectionsForStop($stopName): parsed ${lines.size} lines: $lines")
             emit(lines.map { LineSearchResult(it) })
         }
     }
 
     private fun analyzeLoadedStops(stops: List<StopFeature>) {
+        if (!DEBUG_LOGGING) return
         if (stops.isEmpty()) {
-            Log.w("TransportViewModel", "analyzeLoadedStops: no stops to analyze")
+            Log.w(TAG, "analyzeLoadedStops: no stops to analyze")
             return
         }
         val sample = stops.take(100)
@@ -498,11 +518,11 @@ class TransportViewModel(private val context: Context) : ViewModel() {
         val withDesserte = sample.count { it.properties.desserte.isNotBlank() }
         val emptyDesserte = sample.count { it.properties.desserte.isBlank() }
         val sampleStops = sample.filter { it.properties.nom.isNotBlank() }.take(5)
-        Log.d("TransportViewModel", "Loaded stops analysis (first 100):")
-        Log.d("TransportViewModel", "  With name: $withName, empty name: $emptyName")
-        Log.d("TransportViewModel", "  With desserte: $withDesserte, empty desserte: $emptyDesserte")
+        Log.d(TAG, "Loaded stops analysis (first 100):")
+        Log.d(TAG, "  With name: $withName, empty name: $emptyName")
+        Log.d(TAG, "  With desserte: $withDesserte, empty desserte: $emptyDesserte")
         sampleStops.forEach { stop ->
-            Log.d("TransportViewModel", "  Sample stop: nom='${stop.properties.nom}', desserte='${stop.properties.desserte}'")
+            Log.d(TAG, "  Sample stop: nom='${stop.properties.nom}', desserte='${stop.properties.desserte}'")
         }
     }
 
@@ -510,9 +530,9 @@ class TransportViewModel(private val context: Context) : ViewModel() {
         stopName: String,
         lines: List<String>
     ): List<StopDeparturePreview> = withContext(Dispatchers.Default) {
-        Log.d("TransportViewModel", "getNextDeparturesForStop($stopName, $lines)")
+        if (DEBUG_LOGGING) Log.d(TAG, "getNextDeparturesForStop($stopName, $lines)")
         if (stopName.isBlank() || lines.isEmpty()) {
-            Log.d("TransportViewModel", "getNextDeparturesForStop: early return - blank stopName or empty lines")
+            if (DEBUG_LOGGING) Log.d(TAG, "getNextDeparturesForStop: early return - blank stopName or empty lines")
             return@withContext emptyList()
         }
 
@@ -555,10 +575,10 @@ class TransportViewModel(private val context: Context) : ViewModel() {
             )
             .toList()
             .also { result ->
-                Log.d("TransportViewModel", "getNextDeparturesForStop($stopName): returning ${result.size} departures")
+                if (DEBUG_LOGGING) Log.d(TAG, "getNextDeparturesForStop($stopName): returning ${result.size} departures")
                 if (result.isEmpty()) {
                     Log.w("TransportViewModel", "No departures found for stop '$stopName' with lines $lines")
-                    Log.d("TransportViewModel", "Raptor assets available: ${schedulesRepository.javaClass.kotlin}")
+                    if (DEBUG_LOGGING) Log.d(TAG, "Raptor assets available: ${schedulesRepository.javaClass.kotlin}")
                 }
             }
     }
@@ -634,12 +654,16 @@ class TransportViewModel(private val context: Context) : ViewModel() {
 
         if (filteredStops.isEmpty()) return emptyList()
 
+        // Pre-compute normalized names once to avoid redundant normalizeStopName() calls
+        val normalizedNameCache = HashMap<String, String>(filteredStops.size)
         val stopsByNormalizedName = filteredStops
-            .groupBy { normalizeStopName(it.properties.nom) }
+            .groupBy { stop ->
+                normalizedNameCache.getOrPut(stop.properties.nom) { normalizeStopName(stop.properties.nom) }
+            }
 
         val usedStopNames = mutableSetOf<String>()
         val orderedStops = stopSequences.mapNotNull { (stopNameFromGtfs, sequence) ->
-            val normalizedName = normalizeStopName(stopNameFromGtfs)
+            val normalizedName = normalizedNameCache.getOrPut(stopNameFromGtfs) { normalizeStopName(stopNameFromGtfs) }
             if (!usedStopNames.add(normalizedName)) return@mapNotNull null
 
             val stopFeature = stopsByNormalizedName[normalizedName]?.firstOrNull()
@@ -656,10 +680,10 @@ class TransportViewModel(private val context: Context) : ViewModel() {
         if (orderedStops.isNotEmpty()) {
             val missingStops = filteredStops
                 .asSequence()
-                .filter { normalizeStopName(it.properties.nom) !in usedStopNames }
+                .filter { normalizedNameCache.getOrPut(it.properties.nom) { normalizeStopName(it.properties.nom) } !in usedStopNames }
                 .sortedBy { it.properties.nom.uppercase() }
                 .mapIndexed { index, stop ->
-                    val normalizedName = normalizeStopName(stop.properties.nom)
+                    val normalizedName = normalizedNameCache[stop.properties.nom]!!
                     usedStopNames.add(normalizedName)
 
                     LineStopInfo(
@@ -678,7 +702,7 @@ class TransportViewModel(private val context: Context) : ViewModel() {
         return filteredStops
             .asSequence()
             .sortedBy { it.properties.nom.uppercase() }
-            .distinctBy { normalizeStopName(it.properties.nom) }
+            .distinctBy { normalizedNameCache.getOrPut(it.properties.nom) { normalizeStopName(it.properties.nom) } }
             .mapIndexed { index, stop ->
                 LineStopInfo(
                     stopId = stop.id,

--- a/app/src/main/java/com/pelotcl/app/specific/data/network/LyonTransportApi.kt
+++ b/app/src/main/java/com/pelotcl/app/specific/data/network/LyonTransportApi.kt
@@ -9,6 +9,7 @@ import com.pelotcl.app.generic.data.model.StopCollection
 import com.pelotcl.app.generic.data.model.TrafficAlertsResponse
 import com.pelotcl.app.generic.data.model.Geometry
 import com.pelotcl.app.generic.data.model.TransportLineProperties
+import com.pelotcl.app.generic.data.network.RetrofitInstance
 import com.pelotcl.app.generic.data.network.TransportApi
 import com.pelotcl.app.generic.data.network.TransportLinesQuery
 import com.pelotcl.app.specific.data.mapper.TrafficAlertMapper
@@ -33,16 +34,23 @@ class LyonTransportApi(private val baseUrl: String) : TransportApi {
     /**
      * WFS / GeoJSON lines and stops use the city data host (e.g. Grand Lyon).
      * Traffic alerts are served from the Pelo API on api.dotshell.eu only.
+     * Both share the cached OkHttpClient from RetrofitInstance for HTTP cache + connection pool.
      */
-    private val linesRetrofit: Retrofit = Retrofit.Builder()
-        .baseUrl(baseUrl)
-        .addConverterFactory(GsonConverterFactory.create())
-        .build()
+    private val linesRetrofit: Retrofit = run {
+        val builder = Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(GsonConverterFactory.create())
+        RetrofitInstance.getSharedClient()?.let { builder.client(it) }
+        builder.build()
+    }
 
-    private val trafficAlertsRetrofit: Retrofit = Retrofit.Builder()
-        .baseUrl(TRAFFIC_ALERTS_BASE_URL)
-        .addConverterFactory(GsonConverterFactory.create())
-        .build()
+    private val trafficAlertsRetrofit: Retrofit = run {
+        val builder = Retrofit.Builder()
+            .baseUrl(TRAFFIC_ALERTS_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+        RetrofitInstance.getSharedClient()?.let { builder.client(it) }
+        builder.build()
+    }
 
     private val lyonTrafficApi: LyonTrafficAlertsEndpoint =
         trafficAlertsRetrofit.create(LyonTrafficAlertsEndpoint::class.java)


### PR DESCRIPTION
This pull request introduces several performance optimizations, code quality improvements, and UI refactorings across the codebase. The most significant changes include introducing caching to avoid redundant computation and file I/O in repositories, refactoring Compose UI components for improved efficiency, and cleaning up logging and repository usage in the `TransportViewModel`. Below are the most important changes grouped by theme:

**Performance and Caching Improvements**

* Added caching for the results of `checkAssetsAvailable()` and `getAllStopsWithCoords()` in `RaptorRepository` to avoid repeated file I/O and allocations. These values are now computed once and reused, significantly improving performance in hot paths. [[1]](diffhunk://#diff-bd7b22e1f172f971a370d68000d4bc3ae617abc9afc54e8469d883c174e7e523R73-R79) [[2]](diffhunk://#diff-bd7b22e1f172f971a370d68000d4bc3ae617abc9afc54e8469d883c174e7e523R215-R225) [[3]](diffhunk://#diff-bd7b22e1f172f971a370d68000d4bc3ae617abc9afc54e8469d883c174e7e523L513-R550) [[4]](diffhunk://#diff-bd7b22e1f172f971a370d68000d4bc3ae617abc9afc54e8469d883c174e7e523R563-R564)
* Added a method `getSharedClient()` to `RetrofitInstance` to allow sharing the OkHttpClient and its cache/connection pool across multiple Retrofit instances.

**UI and Compose Refactors**

* Refactored `SimpleSearchBar` to use `LazyColumn` instead of `Column` with `verticalScroll`, improving performance for long lists and enabling better scroll state management. Also updated item rendering to use Compose's `items` API with stable keys. [[1]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51L22-R28) [[2]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51L374-R378) [[3]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51L386-R388) [[4]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51L397-R408) [[5]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51L425-R428) [[6]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51R470) [[7]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51R483-R486) [[8]](diffhunk://#diff-67ccba3f0ab213f9b15c8821914f15f653b42fe9d930fa0d4a1f44a13b55cf51R504)
* Updated `FavoritesBar` to memoize the total width calculation for favorites, avoiding unnecessary recomputation on recomposition.
* Improved `InlineItinerarySheetContent` by providing stable keys to journey items in the list, reducing unnecessary recompositions.

**Repository and Data Layer Cleanups**

* In `SchedulesRepository`, optimized logic for enriching stop lines by reusing already-fetched desserte data and avoiding redundant calls to `checkAssetsAvailable()`.

**ViewModel and Logging Improvements**

* Refactored `TransportViewModel` to use lazy-initialized repositories and a shared cache instance, reducing redundant object creation. Introduced a debug logging flag and centralized logging for easier toggling and improved performance in production. [[1]](diffhunk://#diff-eb9a503929b62caa0983a1d5e6c1faaed31448fc33ac5882bd9f8b2370425654R46-R51) [[2]](diffhunk://#diff-eb9a503929b62caa0983a1d5e6c1faaed31448fc33ac5882bd9f8b2370425654R65-R66) [[3]](diffhunk://#diff-eb9a503929b62caa0983a1d5e6c1faaed31448fc33ac5882bd9f8b2370425654L159-R167) [[4]](diffhunk://#diff-eb9a503929b62caa0983a1d5e6c1faaed31448fc33ac5882bd9f8b2370425654L191-R211) [[5]](diffhunk://#diff-eb9a503929b62caa0983a1d5e6c1faaed31448fc33ac5882bd9f8b2370425654L213-R220) [[6]](diffhunk://#diff-eb9a503929b62caa0983a1d5e6c1faaed31448fc33ac5882bd9f8b2370425654L228-R249)