### PR TITLE
fix(map): keep transport icons out of the collision index so they stop fashing

### DIFF
--- a/app/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/MapCanvas.kt
+++ b/app/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/MapCanvas.kt
@@ -480,6 +480,10 @@ fun MapCanvas(
                             iconImage = iconImageExpr,
                             iconOffset = const(DpOffset(0.dp, (slot * 8).dp)),
                             iconAllowOverlap = const(true),
+                            // Stay out of the global collision index: otherwise every
+                            // live-vehicle source update re-runs symbol placement and
+                            // makes all transport icons flash.
+                            iconIgnorePlacement = const(true),
                             onClick = { f -> onStop(f.firstOrNull()?.properties?.get("nom")?.jsonPrimitive?.contentOrNull) },
                         )
                     }
@@ -543,6 +547,7 @@ fun MapCanvas(
                     source = vehicleSource,
                     iconImage = vehicleIconImage,
                     iconAllowOverlap = const(true),
+                    iconIgnorePlacement = const(true),
                     onClick = { f ->
                         val nom = f.firstOrNull()?.properties?.get("lineName")?.jsonPrimitive?.contentOrNull
                         if (nom != null) { onVehicleClick(nom); ClickResult.Consume } else ClickResult.Pass


### PR DESCRIPTION
This pull request updates the `MapCanvas` component to improve the rendering performance and visual stability of map icons, especially for live vehicle data. The main change is to set the `iconIgnorePlacement` property to `true` for stop and vehicle icons, which prevents unnecessary re-running of symbol placement and eliminates icon flashing when live data updates.

Icon rendering improvements:

* Set `iconIgnorePlacement = true` for stop icons to keep them out of the global collision index, preventing all transport icons from flashing on every live-vehicle source update.
* Set `iconIgnorePlacement = true` for vehicle icons to further avoid unnecessary symbol placement recalculations and visual glitches during live updates.