### PR TITLE
fix(build): import okio.SYSTEM in commonMain so the shared module compiles

### DIFF
--- a/app/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/dataset/DatasetStorage.kt
+++ b/app/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/dataset/DatasetStorage.kt
@@ -4,6 +4,7 @@ import okio.FileSystem
 import okio.HashingSink
 import okio.Path
 import okio.Path.Companion.toPath
+import okio.SYSTEM
 import okio.blackholeSink
 import okio.buffer
 import okio.use

--- a/app/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/offline/GzipFileStore.kt
+++ b/app/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/offline/GzipFileStore.kt
@@ -3,6 +3,7 @@ package eu.dotshell.pelo.generic.data.offline
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
+import okio.SYSTEM
 import okio.buffer
 import okio.gzip
 


### PR DESCRIPTION
## Summary

`:app:compileCommonMainKotlinMetadata` currently fails, so the shared KMP module does not compile:

```
e: .../generic/data/dataset/DatasetStorage.kt:26:80 Unresolved reference 'SYSTEM'.
e: .../generic/data/offline/GzipFileStore.kt:17:45 Unresolved reference 'SYSTEM'.
```

**Root cause.** okio does not declare `SYSTEM` as a member of `FileSystem.Companion`. In okio 3.9.1 it is an *extension property* declared in okio's own `systemFileSystemMain` source set (so it can be excluded from wasm/browser targets, which have no host filesystem):

```kotlin
// okio/systemFileSystemMain/okio/FileSystem.System.kt
expect val FileSystem.Companion.SYSTEM: FileSystem
```

JVM and Native each *additionally* declare a real companion member (`nativeMain`: `val SYSTEM: FileSystem = PosixFileSystem`; JVM likewise), and their `actual` extension is annotated `@Suppress("EXTENSION_SHADOWED_BY_MEMBER")`. That is why `FileSystem.SYSTEM` resolves with no import in `androidMain` and `iosMain` — the member shadows the extension there.

In `commonMain`, however, only the extension is visible, and Kotlin extension properties require an explicit import. Both affected files imported `okio.FileSystem` but not `okio.SYSTEM`, hence the unresolved reference.

**Fix.** Add the missing `import okio.SYSTEM` to the two `commonMain` files. Two import lines, no behaviour change — on Android/iOS the call site still resolves to the same platform filesystem it did before.

## Testing

Verified locally on Linux with the project's own toolchain (Gradle 9.5.0-milestone-5, JDK 21 daemon, AGP 9.0.0, Kotlin 2.3.10) plus a freshly installed Android SDK (platform 36 / build-tools 36.0.0):

| Command | Before | After |
| --- | --- | --- |
| `./gradlew :app:compileCommonMainKotlinMetadata` | FAILED (2 errors) | SUCCESS |
| `./gradlew :app:compileDebugKotlinAndroid` | — | SUCCESS |
| `./gradlew :app:testDebugUnitTest` | — | SUCCESS — 150 tests, 0 failures, 0 errors, 0 skipped (24 classes) |
| `./gradlew :app:assembleDebug` | — | SUCCESS (`app-debug.apk` produced) |
| `./gradlew :app:compileKotlinIosArm64` | — | SUCCESS (klib) |
| `./gradlew :app:compileKotlinIosSimulatorArm64` | — | SUCCESS |
| `./gradlew :baselineprofile:compileNonMinifiedReleaseSources` | — | SUCCESS |

The unit-test suite exercises the changed classes directly (`DatasetInstallerTest`, `DatasetHealthGuardTest`, `DatasetUpdateManagerTest` all construct `DatasetStorage`).

Not covered: linking the iOS framework and running instrumented/baseline-profile tests, which need macOS/Xcode and a device/emulator respectively. `assembleRelease` was also not attempted — it points `signingConfigs.release.storeFile` at an absolute local path (`/home/tristan/Pelo.jks`) that only exists on the maintainer's machine.