### PR TITLE
Perf/startup and recomposition

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,7 +35,8 @@ if (localPropertiesFile.exists()) {
 android {
     signingConfigs {
         create("release") {
-            storeFile = file("/home/tristan/Pelo.jks")
+            storeFile = localProperties.getProperty("RELEASE_STORE_FILE")?.let { rootProject.file(it) }
+                ?: rootProject.file("Pelo.jks")
             storePassword = localProperties.getProperty("RELEASE_STORE_PASSWORD") ?: ""
             keyAlias = localProperties.getProperty("RELEASE_KEY_ALIAS") ?: "pelo-kmp"
             keyPassword = localProperties.getProperty("RELEASE_KEY_PASSWORD") ?: ""

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,89 +20,36 @@
 # hide the original source file name.
 -renamesourcefileattribute SourceFile
 
-# ==================== Retrofit ====================
-# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
-# EnclosingMethod is required to use InnerClasses.
+# ==================== Attributes ====================
+# Signature carries generic type information; InnerClasses and EnclosingMethod are what make it
+# resolvable. Annotations must survive for kotlinx.serialization. These arrived with Retrofit and
+# Gson, both long gone, but the serialization layer needs them just the same.
 -keepattributes Signature, InnerClasses, EnclosingMethod
-
-# Retrofit does reflection on method and parameter annotations.
 -keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
-
-# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
 -keepattributes AnnotationDefault
 
-# Retain service method parameters when optimizing.
--keepclassmembers,allowshrinking,allowobfuscation interface * {
-    @retrofit2.http.* <methods>;
-}
-
-# Ignore annotation used for build tooling.
+# ==================== Suppressions ====================
+# Optional references reachable through OkHttp, which is still here as Ktor's Android engine.
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
-
-# Ignore JSR 305 annotations for embedding nullability information.
 -dontwarn javax.annotation.**
+-dontwarn sun.misc.**
 
 # Guarded by a NoClassDefFoundError try/catch and only used when available.
 -dontwarn kotlin.Unit
 
-# Top-level functions that can only be used by Kotlin.
--dontwarn retrofit2.KotlinExtensions
--dontwarn retrofit2.KotlinExtensions$*
-
-# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
-# and). so it assumes those methods don't exist. You can't make assumptions about what
-# interfaces the Proxy implements based on the call site. This keeps the methods intact
--if interface * { @retrofit2.http.* <methods>; }
--keep,allowobfuscation interface <1>
-
-# Keep inherited services.
--if interface * { @retrofit2.http.* <methods>; }
--keep,allowobfuscation interface * extends <1>
-
-# With R8 full mode generic signatures are stripped for classes that are not
-# kept., we need to keep the Retrofit callback generic signatures to be able to
-# reflect on the type arguments for the Response type.
--keep,allowobfuscation,allowshrinking interface retrofit2.Call
--keep,allowobfuscation,allowshrinking class retrofit2.Response
-
-# R8 full mode strips generic signatures from return types if not kept.
--if interface * { @retrofit2.http.* public *** *(...); }
--keep,allowoptimization,allowshrinking,allowobfuscation class <3>
-
-# ==================== Gson ====================
-# Gson uses generic type information stored in a class file when working with fields. Proguard
-# removes such information by default, so configure it to keep all of it.
--keepattributes Signature
-
-# For using GSON @Expose annotation
--keepattributes *Annotation*
-
-# Gson specific classes
--dontwarn sun.misc.**
-
-# Application classes that will be serialized/deserialized over Gson
-# Keep ALL data model classes (generic + specific) — R8 strips field names otherwise,
-# breaking Gson deserialization (fields without @SerializedName get renamed)
+# ==================== Data models ====================
+# Inherited from the Gson era, when R8 renaming a field broke reflective deserialization.
+# kotlinx.serialization does not read field names at runtime — it generates serializers at compile
+# time — so these blanket keeps are most likely unnecessary now and are costing shrinking across
+# three whole packages. Narrowing them safely needs a release build to verify against, which this
+# machine cannot produce (the signing keystore points at an absolute path from another machine),
+# so they stay until someone can check.
 -keep class eu.dotshell.pelo.generic.data.models.** { *; }
 -keep class eu.dotshell.pelo.specific.data.model.** { *; }
 
-# config.yml is parsed via SnakeYAML → Gson reflection on AppConfig + nested *Data classes.
-# Without these rules R8 full-mode strips the no-arg constructor or class-merges them, causing
-# "Abstract classes can't be instantiated" at runtime.
+# config.json is parsed by kotlinx.serialization into AppConfig and its nested *Data classes.
 -keep class eu.dotshell.pelo.generic.data.config.AppConfig { *; }
 -keep class eu.dotshell.pelo.generic.data.config.**Data { *; }
-
-# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
-# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * extends com.google.gson.TypeAdapter
--keep class * implements com.google.gson.TypeAdapterFactory
--keep class * implements com.google.gson.JsonSerializer
--keep class * implements com.google.gson.JsonDeserializer
-
-# Prevent R8 from leaving Data object members always null
--keepclassmembers,allowobfuscation class * {
-  @com.google.gson.annotations.SerializedName <fields>;
-}
 
 # ==================== Kotlin Serialization ====================
 -keepattributes *Annotation*, InnerClasses

--- a/app/src/main/kotlin/eu/dotshell/pelo/MainActivity.kt
+++ b/app/src/main/kotlin/eu/dotshell/pelo/MainActivity.kt
@@ -97,9 +97,10 @@ class MainActivity : ComponentActivity() {
                 // so background workers and repositories can run before the first activity starts.
 
                 // Parallel preloading - fire and forget (do NOT join)
+                // Warms the process-wide cache the view model will go on to use. It used to build
+                // a throwaway instance, so this decompression happened twice.
                 val cacheJob = launch {
-                    val cache = TransportCacheImpl(applicationContext)
-                    cache.preloadFromDisk()
+                    TransportCacheImpl.getInstance(applicationContext).preloadFromDisk()
                 }
                 
                 // Preload Raptor library in background (only needed for itinerary calculations)

--- a/app/src/main/kotlin/eu/dotshell/pelo/PeloApplication.kt
+++ b/app/src/main/kotlin/eu/dotshell/pelo/PeloApplication.kt
@@ -13,6 +13,7 @@ import eu.dotshell.pelo.platform.BackgroundScheduler
 import eu.dotshell.pelo.platform.FileSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
@@ -22,8 +23,10 @@ class PeloApplication : Application(), Configuration.Provider {
         private const val TAG = "PeloApplication"
     }
 
-    // Application-level coroutine scope for background initialization
-    private val appInitScope = CoroutineScope(Dispatchers.Default)
+    // Application-level coroutine scope for background initialization.
+    // SupervisorJob: the initialisations below are independent, and one throwing must not cancel
+    // the scope and take the others down with it.
+    private val appInitScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     // On-demand WorkManager initialization (replaces automatic ContentProvider init)
     // This defers non-critical startup work until WorkManager is first accessed.
@@ -39,18 +42,24 @@ class PeloApplication : Application(), Configuration.Provider {
         // Ensure AppConfig is loaded synchronously before UI tries to access it
         AppConfigLoader.loadConfig(FileSystem(this))
         
-        // Move all heavy initialization to background to avoid blocking UI thread
+        // Move all heavy initialization to background to avoid blocking UI thread.
+        // One launch each: these were four sequential steps in a single coroutine, so an
+        // exception in any of them silently skipped every step that followed. Only the last two
+        // carried their own try/catch, which meant a failure in the provider init took the
+        // telemetry setup down with it and left no trace of why.
         appInitScope.launch {
-            // Verify Raptor assets are available at startup (async)
-            verifyRaptorAssets()
-            
-            // Initialize transport service provider (contains Retrofit instance)
-            TransportServiceProvider.initialize(this@PeloApplication)
-            
-            // Schedule traffic alerts in background
-            BackgroundScheduler(this@PeloApplication).ensureTrafficAlertsScheduled()
-            
-            // Initialize telemetry in background
+            runCatching { verifyRaptorAssets() }
+                .onFailure { Log.e(TAG, "Raptor asset check failed", it) }
+        }
+        appInitScope.launch {
+            runCatching { TransportServiceProvider.initialize(this@PeloApplication) }
+                .onFailure { Log.e(TAG, "Transport service init failed", it) }
+        }
+        appInitScope.launch {
+            runCatching { BackgroundScheduler(this@PeloApplication).ensureTrafficAlertsScheduled() }
+                .onFailure { Log.w(TAG, "Traffic alert scheduling skipped", it) }
+        }
+        appInitScope.launch {
             initializeTelemetry()
         }
     }

--- a/app/src/main/kotlin/eu/dotshell/pelo/generic/service/NavigationModeForegroundService.kt
+++ b/app/src/main/kotlin/eu/dotshell/pelo/generic/service/NavigationModeForegroundService.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Keeps location alive — and the traveller informed — for the duration of a navigation session.
@@ -45,6 +46,13 @@ class NavigationModeForegroundService : Service() {
     private var locationCallback: LocationCallback? = null
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    // Outlives serviceScope by design, purely to close it down: the finalisation it waits on runs
+    // inside serviceScope, which therefore cannot cancel itself. Held in a field, and bounded by a
+    // timeout, because the anonymous CoroutineScope this replaces was unreachable the moment it
+    // was created — if a child never completed, that join outlived the service with no handle.
+    private val teardownScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     private var tripDetector: TripDetector? = null
     private var tripDetectorInitJob: Job? = null
     private var notificationJob: Job? = null
@@ -96,11 +104,13 @@ class NavigationModeForegroundService : Service() {
         notificationJob = null
         NavigationModeStateStore.setNavigationActive(this, false)
         finalizeTripDetector()
-        // Give the trip finalisation a moment to persist before tearing the scope down; it runs
-        // in serviceScope, so it cannot cancel itself.
-        CoroutineScope(Dispatchers.IO).launch {
-            serviceScope.coroutineContext[Job]?.children?.forEach { it.join() }
+        // Give the trip finalisation a moment to persist before tearing the scope down.
+        teardownScope.launch {
+            withTimeoutOrNull(TEARDOWN_GRACE_MS) {
+                serviceScope.coroutineContext[Job]?.children?.forEach { it.join() }
+            }
             serviceScope.cancel()
+            teardownScope.cancel()
         }
         super.onDestroy()
     }
@@ -180,7 +190,7 @@ class NavigationModeForegroundService : Service() {
         if (TelemetryEmitter.optInManager()?.isOptedIn != true) return
 
         tripDetectorInitJob = serviceScope.launch {
-            val cache = TransportCacheImpl(applicationContext)
+            val cache = TransportCacheImpl.getInstance(applicationContext)
             val stops = runCatching { cache.getStops() }.getOrNull().orEmpty()
             if (stops.isEmpty()) return@launch
 
@@ -285,5 +295,8 @@ class NavigationModeForegroundService : Service() {
 
         private const val CHANNEL_ID = "navigation_mode_channel"
         private const val NOTIFICATION_ID = 7411
+
+        /** How long teardown waits for trip finalisation to persist before cancelling anyway. */
+        private const val TEARDOWN_GRACE_MS = 5_000L
     }
 }

--- a/baselineprofile/src/main/kotlin/eu/dotshell/pelo/baselineprofile/BaselineProfileGenerator.kt
+++ b/baselineprofile/src/main/kotlin/eu/dotshell/pelo/baselineprofile/BaselineProfileGenerator.kt
@@ -1,13 +1,16 @@
 package eu.dotshell.pelo.baselineprofile
 
+import androidx.benchmark.macro.MacrobenchmarkScope
 import androidx.benchmark.macro.junit4.BaselineProfileRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Captures a Baseline Profile for Pelo's cold-start critical path.
+ * Captures a Baseline Profile for Pelo's cold start and its first few destinations.
  *
  * Run on a connected device/emulator (API 28+, 33+ recommended):
  * ```
@@ -17,8 +20,24 @@ import org.junit.runner.RunWith
  * packaged into the release build, and applied by ProfileInstaller on first launch so these paths
  * are AOT-compiled instead of JIT-warmed — cutting cold-start time and first-frame jank.
  *
- * Keep the journey short and deterministic: the more faithfully it mirrors a real cold start, the
- * better the profile. Re-run whenever the startup path changes materially.
+ * ## Before running
+ *
+ * **Open the app by hand once on the target device and accept the terms.** The consent gate is
+ * shown until accepted, its button label comes from `config.json`, and it only enables after a
+ * checkbox is ticked — driving that from here would be brittle. With consent already granted the
+ * gate composes nothing and the journey below reaches the real screens.
+ *
+ * ## Why more than a cold start
+ *
+ * The previous journey stopped at the first frame. The profile it produced had three thousand
+ * MapLibre entries and not one for the lines sheet, a line's details, the itinerary sheet or
+ * settings — so every one of those was JIT-warmed on first use, which is exactly when the user is
+ * watching. The steps below walk the destinations reachable by a stable, localisation-independent
+ * selector.
+ *
+ * Keep it short and deterministic: this runs several times per capture, and anything that can hang
+ * lengthens every iteration. Each step is best-effort — a selector that finds nothing is skipped
+ * rather than failing the capture, because a partial profile is worth more than none.
  */
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
@@ -27,11 +46,55 @@ class BaselineProfileGenerator {
     val rule = BaselineProfileRule()
 
     @Test
-    fun generate() = rule.collect(packageName = "eu.dotshell.pelo") {
+    fun generate() = rule.collect(packageName = PACKAGE_NAME) {
         // Cold launch from the launcher to the first interactive frame (the map scaffold).
         pressHome()
         startActivityAndWait()
         // Let the initial composition / map settle so its classes and methods are exercised.
         device.waitForIdle()
+
+        // The lines sheet: category building, the chip rows, and the icon decoding behind them.
+        if (tapTab(LINES_TAB)) {
+            device.waitForIdle()
+            tapTab(PLAN_TAB)
+            device.waitForIdle()
+        }
+
+        // Settings: the screen itself plus the dataset-info read behind its timetable row.
+        if (tapTab(SETTINGS_TAB)) {
+            device.waitForIdle()
+            tapTab(PLAN_TAB)
+            device.waitForIdle()
+        }
+    }
+
+    /**
+     * Taps a bottom-navigation tab by content description, trying each locale's wording in turn.
+     *
+     * The descriptions are translated (`tab_lines_cd` is "Onglet Lignes" or "Lines tab"), and the
+     * device language is not ours to choose, so both are tried. Returns false when neither is on
+     * screen, leaving the caller to skip that leg.
+     */
+    private fun MacrobenchmarkScope.tapTab(descriptions: List<String>): Boolean {
+        for (description in descriptions) {
+            val target = device.wait(Until.findObject(By.desc(description)), FIND_TIMEOUT_MS)
+            if (target != null) {
+                target.click()
+                return true
+            }
+        }
+        return false
+    }
+
+    private companion object {
+        const val PACKAGE_NAME = "eu.dotshell.pelo"
+
+        /** Short: these are looked up on screens where the tab bar is already drawn. */
+        const val FIND_TIMEOUT_MS = 2_000L
+
+        // Keep in sync with tab_plan_cd / tab_lines_cd / tab_settings_cd in the two strings.xml.
+        val PLAN_TAB = listOf("Onglet Plan", "Map tab")
+        val LINES_TAB = listOf("Onglet Lignes", "Lines tab")
+        val SETTINGS_TAB = listOf("Onglet Paramètres", "Settings tab")
     }
 }

--- a/shared/src/androidMain/kotlin/eu/dotshell/pelo/platform/AppForegroundState.android.kt
+++ b/shared/src/androidMain/kotlin/eu/dotshell/pelo/platform/AppForegroundState.android.kt
@@ -1,0 +1,45 @@
+package eu.dotshell.pelo.platform
+
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Backed by [ProcessLifecycleOwner], which reports the app as a whole rather than one Activity —
+ * the same source [eu.dotshell.pelo.generic.data.telemetry.TelemetryService] uses, and the one
+ * that matches what a user means by having the app open.
+ */
+actual object AppForegroundState {
+
+    private val _isForeground = MutableStateFlow(true)
+    actual val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
+
+    @Volatile
+    private var started = false
+
+    private val observer = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            _isForeground.value = true
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            _isForeground.value = false
+        }
+    }
+
+    actual fun start(context: PlatformContext) {
+        if (started) return
+        started = true
+        // Callers reach this from background initialisation, but ProcessLifecycleOwner and
+        // addObserver are main-thread-only.
+        Handler(Looper.getMainLooper()).post {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/eu/dotshell/pelo/platform/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/eu/dotshell/pelo/platform/Platform.android.kt
@@ -22,6 +22,8 @@ actual fun isUnmeteredNetwork(context: PlatformContext): Boolean = try {
     false
 }
 
+actual fun applicationContextOf(context: PlatformContext): PlatformContext = context.applicationContext
+
 actual fun appVersionName(context: PlatformContext): String = try {
     val info = context.packageManager.getPackageInfo(context.packageName, 0)
     info.versionName ?: "unknown"

--- a/shared/src/androidUnitTest/kotlin/eu/dotshell/pelo/DesserteIndexTest.kt
+++ b/shared/src/androidUnitTest/kotlin/eu/dotshell/pelo/DesserteIndexTest.kt
@@ -1,0 +1,99 @@
+package eu.dotshell.pelo
+
+import eu.dotshell.pelo.generic.data.repository.itinerary.itinerary.buildDessertesByStopName
+import io.raptor.model.Route
+import io.raptor.model.Stop
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the desserte table that replaced the per-call scan in RaptorRepository.
+ *
+ * The old shape rebuilt a groupBy over every route in the period and filtered every stop on each
+ * call, and searchStopsByName made up to fifty of those calls per keystroke. The table has to
+ * produce exactly what that scan produced. Pure synthetic — no PlatformContext, no .bin assets.
+ */
+class DesserteIndexTest {
+
+    private fun route(id: Int, name: String, stopIds: IntArray) = Route(
+        id = id,
+        name = name,
+        stopIds = stopIds,
+        tripCount = 1,
+        stopCountInRoute = stopIds.size,
+        flatStopTimes = IntArray(stopIds.size),
+        tripIds = intArrayOf(id),
+        hasOvernightTrips = false
+    )
+
+    private fun stop(id: Int, name: String, routeIds: IntArray) =
+        Stop(id, name, 45.75, 4.85, routeIds, emptyList())
+
+    /** Two distinct stop sequences under one route id become the A and R directions. */
+    @Test
+    fun bothDirectionsOfARouteAreLabelledAAndR() {
+        val routes = mapOf(
+            1 to listOf(
+                route(1, "C3", intArrayOf(10, 11, 12)),
+                route(1, "C3", intArrayOf(12, 11, 10))
+            )
+        )
+        val table = buildDessertesByStopName(listOf(stop(10, "Bellecour", intArrayOf(1))), routes)
+
+        assertEquals("C3:A,C3:R", table["bellecour"])
+    }
+
+    /** Variants sharing a stop sequence are one direction, not two — this is the distinctBy. */
+    @Test
+    fun duplicateStopSequencesCollapseToOneDirection() {
+        val routes = mapOf(
+            1 to listOf(
+                route(1, "C3", intArrayOf(10, 11)),
+                route(1, "C3", intArrayOf(10, 11))
+            )
+        )
+        val table = buildDessertesByStopName(listOf(stop(10, "Bellecour", intArrayOf(1))), routes)
+
+        assertEquals("C3:A", table["bellecour"])
+    }
+
+    /** Several quays share a physical stop name; their routes merge into one entry. */
+    @Test
+    fun stopsSharingANameAreMergedAndDeduplicated() {
+        val routes = mapOf(
+            1 to listOf(route(1, "C3", intArrayOf(10, 11))),
+            2 to listOf(route(2, "T1", intArrayOf(10, 12)))
+        )
+        val stops = listOf(
+            stop(10, "Bellecour", intArrayOf(1)),
+            stop(20, "BELLECOUR", intArrayOf(2)),
+            // Same route again on a third quay: must not appear twice.
+            stop(21, "bellecour", intArrayOf(1))
+        )
+
+        assertEquals("C3:A,T1:A", buildDessertesByStopName(stops, routes)["bellecour"])
+    }
+
+    /** A stop whose routes are unknown has no desserte at all, rather than an empty string. */
+    @Test
+    fun stopWithNoResolvableRoutesIsAbsent() {
+        val table = buildDessertesByStopName(
+            listOf(stop(10, "Nowhere", intArrayOf(99)), stop(11, "Empty", IntArray(0))),
+            emptyMap()
+        )
+
+        assertNull(table["nowhere"])
+        assertNull(table["empty"])
+    }
+
+    /** The table is looked up with a lowercased name, whatever case the caller asks in. */
+    @Test
+    fun lookupIsCaseInsensitiveThroughLowercasing() {
+        val routes = mapOf(1 to listOf(route(1, "C3", intArrayOf(10))))
+        val table = buildDessertesByStopName(listOf(stop(10, "Gare Part-Dieu", intArrayOf(1))), routes)
+
+        assertEquals("C3:A", table["Gare Part-Dieu".lowercase()])
+        assertEquals("C3:A", table["GARE PART-DIEU".lowercase()])
+    }
+}

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
@@ -649,7 +649,7 @@ private fun RootScaffold(
         }
     }
 
-    val fabDrawableProvider = DrawableProvider(LocalPlatformContext.current)
+    val fabDrawableProvider = remember(context) { DrawableProvider(context) }
 
     var filteredStopsCollection by remember { mutableStateOf<StopCollection?>(null) }
     LaunchedEffect(stops, selectedLineName, itineraryActive, activeJourneys, selectedJourney) {

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
@@ -163,6 +163,7 @@ import eu.dotshell.pelo.generic.data.repository.offline.theme.ThemePreferenceRep
 import eu.dotshell.pelo.generic.ui.viewmodel.TransportLinesUiState
 import eu.dotshell.pelo.generic.ui.viewmodel.TransportStopsUiState
 import eu.dotshell.pelo.generic.ui.viewmodel.TransportViewModel
+import eu.dotshell.pelo.generic.ui.viewmodel.TransportViewModelHolder
 import eu.dotshell.pelo.generic.ui.viewmodel.findStopByCoordinates
 import eu.dotshell.pelo.generic.utils.location.GeoPoint
 import eu.dotshell.pelo.generic.utils.location.LocationPermissionSignal
@@ -229,8 +230,10 @@ fun App(
             try {
                 TransportServiceProvider.initialize(context)
                 Log.i("PeloApp", "TransportProvider init done")
-                val vm = TransportViewModel(context)
-                Log.i("PeloApp", "TransportViewModel constructor done")
+                // Process-scoped: an Activity recreation (a system theme switch is enough) must
+                // reuse this one, not build a second alongside it.
+                val vm = TransportViewModelHolder.getOrCreate(context)
+                Log.i("PeloApp", "TransportViewModel ready")
                 withContext(Dispatchers.Main) {
                     viewModel = vm
                     isInitializing = false
@@ -274,7 +277,12 @@ fun App(
         )
     ) {
         PeloTheme(darkTheme = darkTheme) {
-            TermsConsentGate(onConsentSatisfied = onConsentAccepted) {
+            TermsConsentGate(
+                onConsentSatisfied = onConsentAccepted,
+                // A first launch has a real screen to show before there is any map: let the
+                // launch screen step aside for it rather than hiding it until the timeout.
+                onConsentScreenShown = onReady,
+            ) {
                 TelemetryOptInGate {
                     Box(Modifier.fillMaxSize()) {
                         val vm = viewModel

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
@@ -81,6 +81,7 @@ import kotlinx.coroutines.flow.debounce
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
@@ -1307,14 +1308,19 @@ private fun RootScaffold(
         }
 
         if (showAlertReport) {
-            val nearestStopCandidate = nearestStopTo(userLocation, filteredStopsCollection?.features)
-                ?.let { stop ->
-                    eu.dotshell.pelo.generic.data.models.search.StationSearchResult(
-                        stopName = stop.properties.nom,
-                        stopId = stop.properties.id,
-                        lines = viewModel.parseLineCodesFromDesserte(stop.properties.desserte)
-                    )
-                }
+            // nearestStopTo measures a distance for every stop in the network. Unmemoised it ran
+            // on every recomposition for as long as the report sheet was open — so on every GPS
+            // fix, and on anything else that touched this scaffold.
+            val nearestStopCandidate = remember(userLocation, filteredStopsCollection) {
+                nearestStopTo(userLocation, filteredStopsCollection?.features)
+                    ?.let { stop ->
+                        eu.dotshell.pelo.generic.data.models.search.StationSearchResult(
+                            stopName = stop.properties.nom,
+                            stopId = stop.properties.id,
+                            lines = viewModel.parseLineCodesFromDesserte(stop.properties.desserte)
+                        )
+                    }
+            }
 
             val initialStop = alertReportInitialStopName?.let { name ->
                 eu.dotshell.pelo.generic.data.models.search.StationSearchResult(
@@ -1616,7 +1622,11 @@ private fun PlanContent(
         else -> null
     }
     val showAllLines by viewModel.showAllLinesOnMap.collectAsState(initial = false)
-    val strongLines = allLines?.filter { lineRules.isStrongLine(it.properties.lineName) }
+    // isStrongLine normalises each name, so this walked the whole network on every recomposition —
+    // and, being a key of the remember below, forced a structural comparison of the result too.
+    val strongLines = remember(allLines, lineRules) {
+        allLines?.filter { lineRules.isStrongLine(it.properties.lineName) }
+    }
     val mapLines = remember(strongLines, selectedLineName, allLines, showAllLines) {
         if (allLines == null) return@remember null
         val strongs = strongLines ?: emptyList()
@@ -1631,6 +1641,14 @@ private fun PlanContent(
         }
     }
 
+    // Wrapped once rather than at the call site. FeatureCollection is @Immutable, so Compose
+    // compares it with equals — a structural walk of every line geometry — and a fresh wrapper on
+    // each recomposition guaranteed that walk. Held here, the comparison hits the identity check
+    // in the generated equals instead. During navigation this ran once a second.
+    val mapLinesCollection = remember(mapLines) {
+        mapLines?.let { FeatureCollection(features = it) }
+    }
+
     Box(Modifier.fillMaxSize()) {
         BottomSheetScaffold(
             modifier = Modifier.fillMaxSize(),
@@ -1643,7 +1661,6 @@ private fun PlanContent(
             }
         ) {
             Box(Modifier.fillMaxSize()) {
-                Log.i("PeloApp", "PlanContent: before MapCanvas")
                 MapCanvas(
                     modifier = Modifier.fillMaxSize(),
                     styleUrl = effectiveMapStyle.styleUrl,
@@ -1660,7 +1677,7 @@ private fun PlanContent(
                         isCenteredOnUser -> 0.0
                         else -> null
                     },
-                    lines = mapLines?.let { FeatureCollection(features = it) },
+                    lines = mapLinesCollection,
                     stops = filteredStopsCollection,
                     userLocation = userLocation,
                     heading = heading,
@@ -1727,56 +1744,63 @@ private fun PlanContent(
                                     },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Canvas(
+                                // drawWithCache rather than Canvas: the four needles depend only on
+                                // the size, so they are built when that changes and merely drawn
+                                // afterwards. As a plain draw block they were four Path
+                                // allocations per frame, and this rotates with the map.
+                                Spacer(
                                     modifier = Modifier
                                         .size(24.dp)
                                         .graphicsLayer {
                                             rotationZ = -cameraState.position.bearing.toFloat()
                                         }
-                                ) {
-                                    val width = size.width
-                                    val height = size.height
-                                    val centerX = width / 2f
-                                    val centerY = height / 2f
+                                        .drawWithCache {
+                                            val width = size.width
+                                            val height = size.height
+                                            val centerX = width / 2f
+                                            val centerY = height / 2f
 
-                                    // Path for the North (Red) pointer (Left half)
-                                    val northLeftPath = Path().apply {
-                                        moveTo(centerX, 0f)                     // Top tip
-                                        lineTo(centerX - width * 0.2f, centerY)  // Middle left
-                                        lineTo(centerX, centerY - height * 0.05f)// Center inner
-                                        close()
-                                    }
-                                    // Path for the North (Red) pointer (Right half)
-                                    val northRightPath = Path().apply {
-                                        moveTo(centerX, 0f)                     // Top tip
-                                        lineTo(centerX + width * 0.2f, centerY)  // Middle right
-                                        lineTo(centerX, centerY - height * 0.05f)// Center inner
-                                        close()
-                                    }
+                                            // Path for the North (Red) pointer (Left half)
+                                            val northLeftPath = Path().apply {
+                                                moveTo(centerX, 0f)                     // Top tip
+                                                lineTo(centerX - width * 0.2f, centerY)  // Middle left
+                                                lineTo(centerX, centerY - height * 0.05f)// Center inner
+                                                close()
+                                            }
+                                            // Path for the North (Red) pointer (Right half)
+                                            val northRightPath = Path().apply {
+                                                moveTo(centerX, 0f)                     // Top tip
+                                                lineTo(centerX + width * 0.2f, centerY)  // Middle right
+                                                lineTo(centerX, centerY - height * 0.05f)// Center inner
+                                                close()
+                                            }
 
-                                    // Path for the South (White) pointer (Left half)
-                                    val southLeftPath = Path().apply {
-                                        moveTo(centerX, height)                 // Bottom tip
-                                        lineTo(centerX - width * 0.2f, centerY)  // Middle left
-                                        lineTo(centerX, centerY + height * 0.05f)// Center inner
-                                        close()
-                                    }
-                                    // Path for the South (White) pointer (Right half)
-                                    val southRightPath = Path().apply {
-                                        moveTo(centerX, height)                 // Bottom tip
-                                        lineTo(centerX + width * 0.2f, centerY)  // Middle right
-                                        lineTo(centerX, centerY + height * 0.05f)// Center inner
-                                        close()
-                                    }
+                                            // Path for the South (White) pointer (Left half)
+                                            val southLeftPath = Path().apply {
+                                                moveTo(centerX, height)                 // Bottom tip
+                                                lineTo(centerX - width * 0.2f, centerY)  // Middle left
+                                                lineTo(centerX, centerY + height * 0.05f)// Center inner
+                                                close()
+                                            }
+                                            // Path for the South (White) pointer (Right half)
+                                            val southRightPath = Path().apply {
+                                                moveTo(centerX, height)                 // Bottom tip
+                                                lineTo(centerX + width * 0.2f, centerY)  // Middle right
+                                                lineTo(centerX, centerY + height * 0.05f)// Center inner
+                                                close()
+                                            }
 
-                                    // Draw North halves
-                                    drawPath(northLeftPath, AccentColor)        // Brand orange
-                                    drawPath(northRightPath, AccentColorShade)  // Darker orange for shadow
+                                            onDrawBehind {
+                                                // Draw North halves
+                                                drawPath(northLeftPath, AccentColor)        // Brand orange
+                                                drawPath(northRightPath, AccentColorShade)  // Darker orange for shadow
 
-                                    // Draw South halves
-                                    drawPath(southLeftPath, Sand200)            // Light sand
-                                    drawPath(southRightPath, Color.White)       // Pure white for highlight
-                                }
+                                                // Draw South halves
+                                                drawPath(southLeftPath, Sand200)            // Light sand
+                                                drawPath(southRightPath, Color.White)       // Pure white for highlight
+                                            }
+                                        }
+                                )
                             }
                         }
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/App.kt
@@ -554,8 +554,15 @@ private fun RootScaffold(
     // Keyed on linesUiState as well as the positions: vehicle dots take their colour from the
     // operator palette registered when the lines load, so a stream that starts first has to be
     // re-serialized once that data lands or the dots keep the per-mode fallback colour.
-    val vehiclesGeoJson = remember(activeVehiclePositions, linesUiState) {
-        if (activeVehiclePositions.isEmpty()) null else toVehiclesGeoJson(activeVehiclePositions)
+    // Serialising the fleet builds a JsonObject tree and stringifies it — roughly eight JSON
+    // primitives per vehicle — so it does not belong in composition. Same shape as linesGeoJson
+    // and stopsGeoJson in MapCanvas, and itineraryGeoJson just below.
+    val vehiclesGeoJson by produceState<String?>(null, activeVehiclePositions, linesUiState) {
+        value = if (activeVehiclePositions.isEmpty()) {
+            null
+        } else {
+            withContext(Dispatchers.Default) { toVehiclesGeoJson(activeVehiclePositions) }
+        }
     }
     val vehicleIconName = remember(selectedLine?.lineName) {
         selectedLine?.lineName?.let { LineIconResolver.getDrawableNameForLineName(it) }
@@ -1596,8 +1603,9 @@ private fun PlanContent(
 
     val isGlobalLiveEnabled by viewModel.isGlobalLiveEnabled.collectAsState(initial = false)
     val isLiveTrackingEnabled by viewModel.isLiveTrackingEnabled.collectAsState(initial = false)
-    val vehiclePositions by viewModel.vehiclePositions.collectAsState(initial = emptyList())
-    val globalVehiclePositions by viewModel.globalVehiclePositions.collectAsState(initial = emptyList())
+    // The fleet itself is drawn from RootScaffold; here only the fact that it is non-empty is
+    // needed, and subscribing to the lists for that recomposed this whole screen on every push.
+    val hasVehicles by viewModel.hasActiveVehicles.collectAsState(initial = false)
 
     val isOffline by viewModel.isOffline.collectAsState()
     val offlineDataInfo by viewModel.offlineDataInfo.collectAsState()
@@ -1853,11 +1861,6 @@ private fun PlanContent(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             val isLiveModeEnabled = isLiveTrackingEnabled || isGlobalLiveEnabled
-                            val hasVehicles = when {
-                                isLiveTrackingEnabled -> vehiclePositions.isNotEmpty()
-                                isGlobalLiveEnabled -> globalVehiclePositions.isNotEmpty()
-                                else -> false
-                            }
                             val isActiveNoVehicles = isLiveModeEnabled && !hasVehicles
 
                             val infiniteTransition = rememberInfiniteTransition(label = "live_dot")

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/cache/TransportCacheImpl.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/cache/TransportCacheImpl.kt
@@ -12,6 +12,7 @@ import eu.dotshell.pelo.platform.FileSystem
 import eu.dotshell.pelo.platform.Log
 import eu.dotshell.pelo.platform.PlatformContext
 import eu.dotshell.pelo.platform.Settings
+import eu.dotshell.pelo.platform.applicationContextOf
 import kotlin.concurrent.Volatile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -30,7 +31,7 @@ import kotlinx.serialization.json.Json
  * Cross-platform: gzip + file IO via okio ([GzipFileStore]) under the app cache
  * dir, timestamps via the [Settings] abstraction.
  */
-class TransportCacheImpl(context: PlatformContext) : TransportCache {
+class TransportCacheImpl private constructor(context: PlatformContext) : TransportCache {
 
     private class LineCacheSlot(
         val fileName: String,
@@ -73,6 +74,27 @@ class TransportCacheImpl(context: PlatformContext) : TransportCache {
 
     companion object {
         private const val TAG = "TransportCache"
+
+        @Volatile
+        private var INSTANCE: TransportCacheImpl? = null
+
+        /**
+         * The one cache for the process.
+         *
+         * Everything held in memory here — [stopsCache], [LineCacheSlot.memory] — is an instance
+         * field, so two instances share nothing. Four call sites used to build four of them, and
+         * the most expensive consequence was silent: MainActivity called preloadFromDisk() on a
+         * cache that was unreachable by the time the view model built its own, which then re-read
+         * and re-gunzipped stops, metro and tram lines from disk all over again.
+         *
+         * Constructing it is not free either (it reads config.json, opens Settings and creates the
+         * cache directory), which is a second reason not to do it four times.
+         *
+         * No `synchronized` in commonMain — a @Volatile double-check, as in SchedulesRepository
+         * and RaptorRepository. Built on the application context so no Activity is pinned.
+         */
+        fun getInstance(context: PlatformContext): TransportCacheImpl =
+            INSTANCE ?: TransportCacheImpl(applicationContextOf(context)).also { INSTANCE = it }
 
         private const val KEY_METRO_LINES_TIMESTAMP = "metro_lines_timestamp"
         private const val KEY_TRAM_LINES_TIMESTAMP = "tram_lines_timestamp"

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/cache/TransportCacheImpl.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/cache/TransportCacheImpl.kt
@@ -190,14 +190,23 @@ class TransportCacheImpl private constructor(context: PlatformContext) : Transpo
     }
 
     private suspend fun loadLineCache(slot: LineCacheSlot): List<Feature>? {
-        if (slot.memory != null && isTimestampValid(slot.timestamp)) {
-            if (isInvalidLineCache(slot.memory.orEmpty())) {
-                slot.memory = null
-                slot.timestamp = 0L
-                invalidateLineCache(slot.fileName, slot.timestampKey)
-                return null
+        val memory = slot.memory
+        if (memory != null) {
+            if (isTimestampValid(slot.timestamp)) {
+                if (isInvalidLineCache(memory)) {
+                    slot.memory = null
+                    slot.timestamp = 0L
+                    invalidateLineCache(slot.fileName, slot.timestampKey)
+                    return null
+                }
+                return memory
             }
-            return slot.memory
+            // Expired. The disk copy was written by the same call that filled this field, with
+            // this timestamp, so it cannot be fresher — reading it would gunzip and parse a file
+            // already known to be stale, only to reject it. Drop the memory and refetch.
+            slot.memory = null
+            slot.timestamp = 0L
+            return null
         }
 
         val timestamp = settings.getLong(slot.timestampKey, 0)
@@ -254,8 +263,15 @@ class TransportCacheImpl private constructor(context: PlatformContext) : Transpo
     }
 
     override suspend fun getStops(): List<StopFeature>? = stopsMutex.withLock {
-        if (stopsCache != null && isTimestampValid(stopsTimestamp)) {
-            return@withLock stopsCache
+        if (stopsCache != null) {
+            if (isTimestampValid(stopsTimestamp)) {
+                return@withLock stopsCache
+            }
+            // Same reasoning as loadLineCache: the disk copy shares this timestamp, so it is
+            // stale too and re-reading it is wasted work.
+            stopsCache = null
+            stopsTimestamp = 0L
+            return@withLock null
         }
 
         val timestamp = settings.getLong(KEY_STOPS_TIMESTAMP, 0)

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/cache/journey/JourneyCache.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/cache/journey/JourneyCache.kt
@@ -67,6 +67,9 @@ class JourneyCache private constructor(context: PlatformContext) {
         private const val MAX_DISK_CACHE_SIZE_BYTES = 5 * 1024 * 1024L
         private const val MAX_DISK_ENTRIES = 200
 
+        /** Writes between two disk-size sweeps. See [enforceDiskSizeLimitIfDue]. */
+        private const val DISK_SWEEP_EVERY = 20
+
         @Volatile
         private var INSTANCE: JourneyCache? = null
 
@@ -180,11 +183,31 @@ class JourneyCache private constructor(context: PlatformContext) {
         diskMutex.withLock {
             try {
                 GzipFileStore.writeGzip(getCacheFilePath(cacheKey), json.encodeToString(journeys))
-                enforceDiskSizeLimit()
+                enforceDiskSizeLimitIfDue()
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to write cache to disk: ${e.message}")
             }
         }
+    }
+
+    /**
+     * The sweep lists the whole cache directory and asks the filesystem for two pieces of metadata
+     * per file, across up to [MAX_DISK_ENTRIES] of them. Running that after every single write was
+     * far more expensive than the write itself, and pointless: the limits cannot be exceeded by
+     * more than [DISK_SWEEP_EVERY] entries in between.
+     *
+     * Counter guarded by the caller's diskMutex. It starts due, so the first write of a session
+     * still trims a cache left oversized by the previous one.
+     */
+    private var writesSinceSweep: Int = DISK_SWEEP_EVERY
+
+    private fun enforceDiskSizeLimitIfDue() {
+        if (writesSinceSweep < DISK_SWEEP_EVERY) {
+            writesSinceSweep++
+            return
+        }
+        writesSinceSweep = 0
+        enforceDiskSizeLimit()
     }
 
     private fun readFromDiskPath(path: String): List<JourneyResult>? {
@@ -204,15 +227,20 @@ class JourneyCache private constructor(context: PlatformContext) {
             val files = GzipFileStore.list(cacheDir)
             if (files.isEmpty()) return
 
-            val sortedFiles = files.sortedBy { GzipFileStore.lastModified(it.toString()) }
-            var fileCount = sortedFiles.size
-            var totalSize = sortedFiles.sumOf { GzipFileStore.size(it.toString()) }
+            // Size read once per file and carried along: it used to be asked for a second time
+            // inside the eviction loop, so every sweep cost two metadata calls per entry.
+            val oldestFirst = files
+                .map { it.toString() }
+                .sortedBy { GzipFileStore.lastModified(it) }
+                .map { it to GzipFileStore.size(it) }
+            var fileCount = oldestFirst.size
+            var totalSize = oldestFirst.sumOf { (_, size) -> size }
 
-            for (path in sortedFiles) {
+            for ((path, size) in oldestFirst) {
                 if (fileCount <= MAX_DISK_ENTRIES && totalSize <= MAX_DISK_CACHE_SIZE_BYTES) break
-                totalSize -= GzipFileStore.size(path.toString())
+                totalSize -= size
                 fileCount--
-                GzipFileStore.delete(path.toString())
+                GzipFileStore.delete(path)
             }
         } catch (e: Exception) {
             Log.w(TAG, "Failed to enforce disk size limit: ${e.message}")
@@ -221,12 +249,21 @@ class JourneyCache private constructor(context: PlatformContext) {
 
     /**
      * Trim memory under pressure. [level] is the Android `ComponentCallbacks2` trim level
-     * (20 = UI_HIDDEN, 40 = BACKGROUND). Best-effort and lock-free (a memory hint), so the
-     * disk cache always remains as the source of truth.
+     * (20 = UI_HIDDEN, 40 = BACKGROUND). The disk cache always remains as the source of truth,
+     * so skipping a trim costs nothing.
+     *
+     * Called from onTrimMemory, which is not a coroutine, so the mutex is taken with tryLock
+     * rather than withLock. It used to clear the map with no lock at all, while suspending
+     * callers were free to be halfway through an insertion or an eviction on the same
+     * LinkedHashMap — a data race on a structure that is not thread-safe.
      */
     fun trimMemory(level: Int) {
-        if (level >= 20) {
-            runCatching { memoryCache.clear() }
+        if (level < 20) return
+        if (!memoryMutex.tryLock()) return  // busy: this is a hint, not an obligation
+        try {
+            memoryCache.clear()
+        } finally {
+            memoryMutex.unlock()
         }
     }
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/config/AppVehiclePositionsService.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/config/AppVehiclePositionsService.kt
@@ -6,6 +6,7 @@ import eu.dotshell.pelo.generic.data.models.realtime.vehiclepositions.VehiclePos
 import eu.dotshell.pelo.generic.data.network.VehiclePositionsService
 import eu.dotshell.pelo.platform.Log
 import eu.dotshell.pelo.platform.createHttpClientEngine
+import eu.dotshell.pelo.platform.ioDispatcher
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.client.plugins.sse.sse
@@ -14,6 +15,7 @@ import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.serialization.json.Json
@@ -93,7 +95,12 @@ class AppVehiclePositionsService(
             val backoff = (1_000L * (1L shl attempt.coerceAtMost(5).toInt())).coerceAtMost(30_000L)
             delay(backoff)
             true
-        }
+        }.flowOn(ioDispatcher)
+        // Without this the whole stream ran in the collector's context, and both collectors are
+        // viewModelScope.launch {} — i.e. Dispatchers.Main.immediate. Every SSE event parsed the
+        // entire fleet's JSON on the UI thread. flowOn goes last so it covers the channelFlow and
+        // the retry alike; the downstream per-line filters stay with the collector, which is where
+        // they belong.
     }
 
     private fun parsePositionsEventData(data: String): List<SimpleVehiclePosition> {

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/dataset/DatasetUpdateScheduler.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/dataset/DatasetUpdateScheduler.kt
@@ -1,6 +1,8 @@
 package eu.dotshell.pelo.generic.data.dataset
 
 import eu.dotshell.pelo.platform.Log
+import eu.dotshell.pelo.platform.ioDispatcher
+import kotlinx.coroutines.withContext
 
 /**
  * Decides WHEN an over-the-air dataset check may run, and drives it. Two gates, both
@@ -31,19 +33,27 @@ class DatasetUpdateScheduler(
      * Runs a check if both gates allow it, recording the attempt so the interval holds.
      * Returns the outcome, or null when a gate blocked it. Safe to call at every launch.
      */
-    suspend fun maybeCheck(): CheckResult? {
-        if (!shouldCheck(now(), lastCheck(), isUnmetered(), minIntervalMs)) return null
+    suspend fun maybeCheck(): CheckResult? = withContext(ioDispatcher) {
+        if (!shouldCheck(now(), lastCheck(), isUnmetered(), minIntervalMs)) return@withContext null
         // Record BEFORE the network call so a failure still spaces out retries.
         recordCheck(now())
         val result = manager.checkForUpdate()
         Log.i(TAG, "Dataset check: $result")
-        return result
+        result
     }
 
-    /** Forces a check regardless of interval or network (the settings "check now" action). */
-    suspend fun checkNow(): CheckResult {
+    /**
+     * Forces a check regardless of interval or network (the settings "check now" action).
+     *
+     * The dispatcher is pinned here, on both entry points, rather than at the call sites: none of
+     * DatasetStorage, DatasetInstaller or DatasetHealthGuard switches threads, so everything below
+     * runs on whatever the caller brought. The startup path came in on ioDispatcher, but the
+     * settings row calls this from rememberCoroutineScope() — that is the main thread, writing
+     * megabytes through okio and hashing the whole staged dataset on it.
+     */
+    suspend fun checkNow(): CheckResult = withContext(ioDispatcher) {
         recordCheck(now())
-        return manager.checkForUpdate()
+        manager.checkForUpdate()
     }
 
     private fun lastCheck(): Long =

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/models/stops/StationInfo.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/models/stops/StationInfo.kt
@@ -1,8 +1,13 @@
 package eu.dotshell.pelo.generic.data.models.stops
 
+import androidx.compose.runtime.Immutable
+
 /**
  * Station data for display in the bottom sheet
+ *
+ * @Immutable for the two list properties; all vals, built once by the caller.
  */
+@Immutable
 data class StationInfo(
     val nom: String,
     val lignes: List<String>, // List of line names (ex: ["A", "D", "F1"])

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/models/ui/AllSchedulesInfo.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/models/ui/AllSchedulesInfo.kt
@@ -1,5 +1,9 @@
 package eu.dotshell.pelo.generic.data.models.ui
 
+import androidx.compose.runtime.Immutable
+
+/** @Immutable for the list and map properties; all vals, built once by the caller. */
+@Immutable
 data class AllSchedulesInfo(
     val lineName: String,
     val directionName: String,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/api/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/api/SchedulesRepository.kt
@@ -5,7 +5,7 @@ import eu.dotshell.pelo.generic.data.models.search.LineSearchResult
 
 interface SchedulesRepository {
     suspend fun searchStopsByName(query: String): List<StationSearchResult>
-    fun searchLinesByName(query: String): List<LineSearchResult>
+    suspend fun searchLinesByName(query: String): List<LineSearchResult>
     fun getAllRouteNames(): List<String>
     fun getHeadsigns(routeName: String): Map<Int, String>
     fun getDesserteForStop(stopName: String): String?

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/itinerary/itinerary/JourneyLeg.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/itinerary/itinerary/JourneyLeg.kt
@@ -1,5 +1,6 @@
 package eu.dotshell.pelo.generic.data.repository.itinerary.itinerary
 
+import androidx.compose.runtime.Immutable
 import kotlinx.serialization.Serializable
 
 /**
@@ -19,7 +20,12 @@ enum class JourneyLegKind {
  * Data class representing a leg of a journey.
  * A coordinate endpoint (walk leg from/to an address or GPS point) uses stopId "-1";
  * its lat/lon then come from the query point rather than a network stop.
+ *
+ * @Immutable for `intermediateStops`, the one property the compiler cannot infer as stable.
+ * Instability here propagated into both JourneyResult and NavigationModeUiState. The promise
+ * holds: all vals, IntermediateStop is primitives only, and the derived members read no clock.
  */
+@Immutable
 data class JourneyLeg(
     val fromStopId: String,
     val fromStopName: String,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/itinerary/itinerary/JourneyResult.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/itinerary/itinerary/JourneyResult.kt
@@ -1,8 +1,18 @@
 package eu.dotshell.pelo.generic.data.repository.itinerary.itinerary
 
+import androidx.compose.runtime.Immutable
+
 /**
  * Data class representing a journey result
+ *
+ * @Immutable because `legs` is a read-only List, which the compiler cannot prove is not a
+ * MutableList someone else still holds — so without this the whole type is inferred unstable, and
+ * so is every composable taking one. It is the item type of the itinerary list, so that mattered.
+ * The promise holds: every property is a val, the derived members read only those vals, and the
+ * legs list is built once by RaptorRepository and handed over. Do not add a getter here that reads
+ * a clock.
  */
+@Immutable
 data class JourneyResult(
     val departureTime: Int, // in seconds from midnight
     val arrivalTime: Int, // in seconds from midnight

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/itinerary/itinerary/RaptorRepository.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/itinerary/itinerary/RaptorRepository.kt
@@ -372,21 +372,84 @@ class RaptorRepository private constructor(private val context: PlatformContext)
      * must be expanded into the real names with this list.
      */
     fun getAllRouteNames(): Set<String> =
-        getRoutesForPeriod("school_on_weekdays").map { it.name }.toSet()
+        indexFor(PERIOD_SCHOOL_ON_WEEKDAYS).sortedRouteNames.toSet()
+
+    /**
+     * Distinct, sorted route names of the ACTIVE period.
+     *
+     * Non-suspend on purpose: it feeds resolveScheduleRouteName, which sits on non-suspend
+     * schedule paths that are called several times per timetable load. It used to go through
+     * searchLinesByName(""), which wrapped every name in a LineSearchResult — one line-type
+     * classification each — only for the caller to unwrap them again.
+     */
+    fun currentPeriodRouteNames(): List<String> {
+        val period = raptorLibrary?.getCurrentPeriod() ?: return emptyList()
+        return indexFor(period).sortedRouteNames
+    }
 
     private data class RouteVariant(
         val route: Route,
         val stopNames: List<String>
     )
 
-    private fun getVariantsForRoute(periodId: String, routeName: String): List<RouteVariant> {
-        val routes = getRoutesForPeriod(periodId)
-        val stops = getStopsForPeriod(periodId)
+    // Note: [buildDessertesByStopName] lives at the bottom of this file, top-level and internal,
+    // so the one piece of index-building whose semantics are not obvious can be tested directly.
+
+    /**
+     * Lookup tables for one schedule period, built once and kept.
+     *
+     * Keying on the period id alone is safe: [getRoutesForPeriod] and [getStopsForPeriod] delegate
+     * to RaptorLibrary, which parses each period exactly once, and a staged dataset is only ever
+     * promoted at cold start before anything reads it (see [initialize]). A period id therefore
+     * names the same data for the life of the process, and there is nothing to invalidate when the
+     * active period changes — the key already carries that.
+     *
+     * Where the callers used to compare names with `equals(ignoreCase = true)`, the tables key on
+     * `lowercase()`. The two agree for every name in this dataset, which is French stop and line
+     * names.
+     */
+    private class PeriodIndex(routes: List<Route>, private val stops: List<Stop>) {
         val stopById = stops.associateBy { it.id }
-        return routes
-            .filter { it.name.equals(routeName, ignoreCase = true) }
+        val routesById = routes.groupBy { it.id }
+        val routesByLowercaseName = routes.groupBy { it.name.lowercase() }
+
+        /** Distinct route names, sorted — the shape both the line search and the name lookup want. */
+        val sortedRouteNames = routes.map { it.name }.distinct().sorted()
+
+        /**
+         * Stop name (lowercased) to its desserte string, e.g. `"C3:A,C3:R"`.
+         *
+         * Built in a single pass on first use. searchStopsByName asks for up to fifty of these per
+         * keystroke, and the previous shape rebuilt a groupBy over every route in the period and
+         * scanned every stop on each one of those calls.
+         */
+        val dessertesByStopName: Map<String, String> by lazy {
+            buildDessertesByStopName(stops, routesById)
+        }
+    }
+
+    /**
+     * Copy-on-write: the map is replaced, never mutated, so a reader can never observe a half-built
+     * table without a lock — and these are read from non-suspend paths, where the repository's
+     * Mutex is not available. Two threads racing on a miss build the same index twice and one wins,
+     * the same benign outcome as the @Volatile singletons elsewhere in this file.
+     */
+    @Volatile
+    private var periodIndexes: Map<String, PeriodIndex> = emptyMap()
+
+    private fun indexFor(periodId: String): PeriodIndex {
+        periodIndexes[periodId]?.let { return it }
+        val index = PeriodIndex(getRoutesForPeriod(periodId), getStopsForPeriod(periodId))
+        periodIndexes = periodIndexes + (periodId to index)
+        return index
+    }
+
+    private fun getVariantsForRoute(periodId: String, routeName: String): List<RouteVariant> {
+        val index = indexFor(periodId)
+        return index.routesByLowercaseName[routeName.lowercase()]
+            .orEmpty()
             .map { route ->
-                val stopNames = route.stopIds.toList().mapNotNull { stopById[it]?.name }
+                val stopNames = route.stopIds.toList().mapNotNull { index.stopById[it]?.name }
                 RouteVariant(route, stopNames)
             }
             .filter { it.stopNames.isNotEmpty() }
@@ -890,19 +953,23 @@ class RaptorRepository private constructor(private val context: PlatformContext)
         return now.hour * 3600 + now.minute * 60 + now.second
     }
 
-    fun searchLinesByName(query: String): List<LineSearchResult> {
-        val currentPeriod = raptorLibrary?.getCurrentPeriod() ?: return emptyList()
-        val routes = getRoutesForPeriod(currentPeriod)
-        val allNames = routes
-            .map { it.name }
-            .distinct()
+    /**
+     * Suspending because it scans the active period's routes, and the caller is a debounced
+     * LaunchedEffect — i.e. the main thread. searchStopsByName next to it was already doing this;
+     * this one was not, so every keystroke ran the scan on the UI thread.
+     */
+    suspend fun searchLinesByName(query: String): List<LineSearchResult> = withContext(ioDispatcher) {
+        val currentPeriod = raptorLibrary?.getCurrentPeriod() ?: return@withContext emptyList()
+        val allNames = indexFor(currentPeriod).sortedRouteNames
+        // Hoisted: this was resolved once per result.
+        val rules = TransportServiceProvider.getTransportLineRules()
         if (query.isBlank()) {
-            return allNames.sorted().map {
-                LineSearchResult(lineName = it, category = TransportServiceProvider.getTransportLineRules().getTransportType(it))
+            return@withContext allNames.map {
+                LineSearchResult(lineName = it, category = rules.getTransportType(it))
             }
         }
         val normalizedQuery = query.trim().uppercase()
-        return allNames
+        allNames
             .filter {
                 it.uppercase().contains(normalizedQuery) || normalizedQuery.contains(it.uppercase())
             }
@@ -917,10 +984,7 @@ class RaptorRepository private constructor(private val context: PlatformContext)
             ))
             .take(20)
             .map { lineName ->
-                LineSearchResult(
-                    lineName = lineName,
-                    category = TransportServiceProvider.getTransportLineRules().getTransportType(lineName)
-                )
+                LineSearchResult(lineName = lineName, category = rules.getTransportType(lineName))
             }
     }
 
@@ -971,23 +1035,43 @@ class RaptorRepository private constructor(private val context: PlatformContext)
         }
 
         val period = raptorLibrary?.getCurrentPeriod() ?: PERIOD_SCHOOL_ON_WEEKDAYS
-        val stops = getStopsForPeriod(period)
-        val routes = getRoutesForPeriod(period)
-        val routeById = routes.groupBy { it.id }
-
-        val dessertes = stops
-            .filter { it.name.equals(stopName, ignoreCase = true) }
-            .flatMap { stop ->
-                stop.routeIds.flatMap { routeId ->
-                    val variants = routeById[routeId].orEmpty()
-                        .distinctBy { it.stopIds.joinToString(",") }
-                    variants.mapIndexed { index, route ->
-                        val dir = if (index == 0) "A" else "R"
-                        "${route.name}:$dir"
-                    }
-                }
-            }
-            .distinct()
-        return if (dessertes.isEmpty()) null else dessertes.joinToString(",")
+        return indexFor(period).dessertesByStopName[stopName.lowercase()]
     }
+}
+
+/**
+ * Builds the whole "stop name -> desserte" table for one period in a single pass.
+ *
+ * The desserte of a stop is the comma-joined list of `"<routeName>:<A|R>"` entries for every route
+ * calling there, where A/R distinguishes the two directions — determined, as it always was, by the
+ * order of a route's distinct stop sequences.
+ *
+ * All stops sharing a name contribute to the same entry: the network has several stop records per
+ * physical stop (one per quay), and the caller asks by name. Names are folded with `lowercase()`
+ * where the previous per-call scan used `equals(ignoreCase = true)`; the two agree for every name
+ * in this dataset.
+ *
+ * Top-level and internal so it can be exercised without a PlatformContext or the `.bin` assets.
+ */
+internal fun buildDessertesByStopName(
+    stops: List<Stop>,
+    routesById: Map<Int, List<Route>>
+): Map<String, String> {
+    val byName = LinkedHashMap<String, MutableList<String>>()
+    for (stop in stops) {
+        val bucket = byName.getOrPut(stop.name.lowercase()) { mutableListOf() }
+        for (routeId in stop.routeIds) {
+            routesById[routeId].orEmpty()
+                .distinctBy { it.stopIds.joinToString(",") }
+                .forEachIndexed { index, route ->
+                    bucket += "${route.name}:${if (index == 0) "A" else "R"}"
+                }
+        }
+    }
+    val out = HashMap<String, String>(byName.size)
+    for ((name, entries) in byName) {
+        val joined = entries.distinct().joinToString(",")
+        if (joined.isNotEmpty()) out[name] = joined
+    }
+    return out
 }

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/offline/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/offline/SchedulesRepository.kt
@@ -123,12 +123,16 @@ class SchedulesRepository private constructor(context: PlatformContext) : ApiSch
         return results
     }
 
-    override fun searchLinesByName(query: String): List<LineSearchResult> {
+    override suspend fun searchLinesByName(query: String): List<LineSearchResult> {
         return raptorRepository.searchLinesByName(query)
     }
 
     override fun getAllRouteNames(): List<String> {
-        return raptorRepository.searchLinesByName("").map { it.lineName }.distinct().sorted()
+        // Same names as before, without going through searchLinesByName(""), which wrapped each
+        // one in a LineSearchResult — a line-type classification apiece — only to be unwrapped
+        // again here. Stays non-suspend: resolveScheduleRouteName calls it several times per
+        // timetable load from non-suspend code.
+        return raptorRepository.currentPeriodRouteNames()
     }
 
     fun getAllBusLikeRouteNames(): List<String> {

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/offline/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/offline/SchedulesRepository.kt
@@ -38,9 +38,16 @@ class SchedulesRepository private constructor(context: PlatformContext) : ApiSch
 
         fun trimCaches(level: Int) {
             // 20 = TRIM_MEMORY_UI_HIDDEN, 40 = TRIM_MEMORY_BACKGROUND (android ComponentCallbacks2).
-            // Best-effort and lock-free (a memory hint); the Raptor data is the source of truth.
-            if (level >= 20) {
-                runCatching { searchCache.clear() }
+            // Best-effort (a memory hint); the Raptor data is the source of truth, so skipping
+            // this costs nothing. Called from onTrimMemory, which is not a coroutine, hence
+            // tryLock rather than withLock — but it does need the lock: clearing with none while
+            // a suspending caller is mid-insertion is a race on a LinkedHashMap.
+            if (level < 20) return
+            if (!searchCacheMutex.tryLock()) return
+            try {
+                searchCache.clear()
+            } finally {
+                searchCacheMutex.unlock()
             }
         }
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/offline/search/SearchHistoryItem.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/offline/search/SearchHistoryItem.kt
@@ -1,12 +1,18 @@
 package eu.dotshell.pelo.generic.data.repository.offline.search
 
+import androidx.compose.runtime.Immutable
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 
 /**
  * Model for a search history item: a stop, a line, or a geocoded address/POI.
  * Address entries carry their coordinates so they can be re-selected without re-geocoding.
+ *
+ * @Immutable for `lines`. This is the item type of the search-history list, so the instability
+ * cost a skip on every row while scrolling. `timestamp` reads the clock in its default value —
+ * at construction, not on read — so the promise holds.
  */
+@Immutable
 @Serializable
 data class SearchHistoryItem(
     val query: String,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/online/VehiclePositionsRepository.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/data/repository/online/VehiclePositionsRepository.kt
@@ -20,8 +20,11 @@ class VehiclePositionsRepository(
     }
 
     /**
-     * Streams vehicle positions for a single line. With the SIRI backend this
-     * is a focused poll of that line only — much cheaper than the full sweep.
+     * Streams vehicle positions for a single line.
+     *
+     * Note that this is not a per-line subscription: the SIRI endpoint publishes the whole fleet
+     * on one stream, so the service takes that stream and filters it. The saving is in what
+     * reaches the UI, not in what crosses the network.
      */
     fun streamVehiclePositionsByLine(lineName: String): Flow<Result<List<SimpleVehiclePosition>>> {
         return vehiclePositionsService.streamVehiclePositionsByLine(lineName)

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/service/NavigationModeController.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/service/NavigationModeController.kt
@@ -189,7 +189,7 @@ class NavigationModeController(
         if (TelemetryEmitter.optInManager()?.isOptedIn != true) return
 
         tripDetectorInitJob = scope.launch {
-            val stops = runCatching { TransportCacheImpl(context).getStops() }.getOrNull().orEmpty()
+            val stops = runCatching { TransportCacheImpl.getInstance(context).getStops() }.getOrNull().orEmpty()
             if (stops.isEmpty()) return@launch
 
             val telemetryConfig = runCatching { AppConfigLoader.getConfig().telemetry }.getOrNull()

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/DepartureListItem.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/DepartureListItem.kt
@@ -33,8 +33,9 @@ fun DepartureListItem(
     departureTime: String,
     onClick: () -> Unit
 ) {
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
-    val strings = StringProvider(LocalPlatformContext.current)
+    val context = LocalPlatformContext.current
+    val drawableProvider = remember(context) { DrawableProvider(context) }
+    val strings = remember(context) { StringProvider(context) }
     val drawableName = remember(lineName) {
         LineIconResolver.getDrawableNameForLineName(lineName)
     }

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/DepartureListItem.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/DepartureListItem.kt
@@ -77,17 +77,20 @@ fun DepartureListItem(
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1
                 )
+                // Resolved once: getDepartureColor converts an Instant to local time on each call,
+                // and this ran twice per row.
+                val departureColor = DepartureManager.getDepartureColor(departureTime)
                 Text(
                     text = DepartureManager.formatDisplayTime(departureTime),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = DepartureManager.getDepartureColor(departureTime)
+                    color = departureColor
                 )
                 DepartureManager.formatRelativeDeparture(departureTime, strings)?.let { relativeText ->
                     Text(
                         text = relativeText,
                         style = MaterialTheme.typography.bodySmall,
-                        color = DepartureManager.getDepartureColor(departureTime)
+                        color = departureColor
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/MapCanvas.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/MapCanvas.kt
@@ -100,6 +100,20 @@ private val BUNDLED_STYLE_DESCRIPTORS = mapOf(
 private const val BASEMAP_VECTOR_SOURCE_ID = "openmaptiles"
 
 /**
+ * Stop icon tiers as (priority, minimum zoom, layer id prefix): metro and funicular appear from
+ * 12.5, tram from 14, bus from 17. Priority is compared as a string to avoid numeric conversion
+ * mismatches in the layer filter.
+ *
+ * At file level rather than in the map content lambda, where it was rebuilt on every recomposition
+ * of that scope.
+ */
+private val STOP_PRIORITY_TIERS = listOf(
+    Triple("2", 12.5f, "transport-stops-priority-2"),
+    Triple("1", 14.0f, "transport-stops-priority-1"),
+    Triple("0", 17.0f, "transport-stops-priority-0")
+)
+
+/**
  * Source layers holding the basemap's named features: `place` covers localities — hamlets,
  * neighbourhoods, suburbs, towns — and `poi` covers named points such as shops and venues.
  */
@@ -183,8 +197,6 @@ fun MapCanvas(
     bearing: Double? = null,
     tilt: Double? = null,
 ) {
-    Log.i("MapCanvas", "compose entered, stops=${stops?.features?.size} shouldRenderStops=${!selectedLineName.isNullOrBlank() || initialZoom >= STOP_RENDER_MIN_ZOOM} lines=${lines?.features?.size}")
-
     val fallbackPainter = remember {
         object : Painter() {
             override val intrinsicSize: Size = Size(14f, 14f)
@@ -449,7 +461,6 @@ fun MapCanvas(
         cameraState = cameraState,
         options = mapOptions,
     ) {
-        Log.i("MapCanvas", "MaplibreMap content lambda compose start")
         // key(styleUrl) ensures all layers/sources are rebuilt when the style changes.
         androidx.compose.runtime.key(styleUrl) {
             // ------------------------------------------------------------------
@@ -618,15 +629,7 @@ fun MapCanvas(
                     fallback = fallback,
                 )
 
-                // Loop over slots to stack multiple icons vertically at multi-line stations (like Bellecour).
-                // Priority gates the zoom (metro/funicular from 12.5f, tram from 14f, bus from 17f).
-                // String-based priority comparison to avoid numerical conversion mismatches.
-                val tiers = listOf(
-                    Triple("2", 12.5f, "transport-stops-priority-2"),
-                    Triple("1", 14.0f, "transport-stops-priority-1"),
-                    Triple("0", 17.0f, "transport-stops-priority-0")
-                )
-                for ((priority, minZoom, baseId) in tiers) {
+                for ((priority, minZoom, baseId) in STOP_PRIORITY_TIERS) {
                     val actualMinZoom = if (itineraryGeoJson != null) 12.5f else minZoom
                     for (slot in slots) {
                         SymbolLayer(

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/StationBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/StationBottomSheet.kt
@@ -72,8 +72,9 @@ fun StationBottomSheet(
     val departuresInset = 20.dp
     val actionsInset = 8.dp
 
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
-    val strings = StringProvider(LocalPlatformContext.current)
+    val platformContext = LocalPlatformContext.current
+    val drawableProvider = remember(platformContext) { DrawableProvider(platformContext) }
+    val strings = remember(platformContext) { StringProvider(platformContext) }
     val realtimeConfig = remember { eu.dotshell.pelo.generic.service.TransportServiceProvider.getRealtimeConfig() }
     val stationName = stationInfo?.nom
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/search/bar/lines/LineSearchResultItem.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/search/bar/lines/LineSearchResultItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.remember
 import eu.dotshell.pelo.generic.data.models.search.LineSearchResult
 import androidx.compose.material3.MaterialTheme
 import eu.dotshell.pelo.generic.utils.graphics.LineIconResolver
@@ -29,11 +30,14 @@ fun LineSearchResultItem(
     lineResult: LineSearchResult,
     onClick: () -> Unit
 ) {
-    val drawableName = LineIconResolver.getDrawableNameForLineName(lineResult.lineName)
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
-    val stringProvider = StringProvider(LocalPlatformContext.current)
-    val hasDrawable = drawableProvider.hasDrawable(drawableName)
-    val hasModeBus = drawableProvider.hasDrawable("mode_bus")
+    val context = LocalPlatformContext.current
+    val drawableProvider = remember(context) { DrawableProvider(context) }
+    val stringProvider = remember(context) { StringProvider(context) }
+    val drawableName = remember(lineResult.lineName) {
+        LineIconResolver.getDrawableNameForLineName(lineResult.lineName)
+    }
+    val hasDrawable = remember(drawableName) { drawableProvider.hasDrawable(drawableName) }
+    val hasModeBus = remember { drawableProvider.hasDrawable("mode_bus") }
 
     ListItem(
         headlineContent = {

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/search/bar/stops/SearchConnectionBadge.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/search/bar/stops/SearchConnectionBadge.kt
@@ -3,6 +3,7 @@ package eu.dotshell.pelo.generic.ui.components.search.bar.stops
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import eu.dotshell.pelo.generic.utils.graphics.LineIconResolver
@@ -12,9 +13,12 @@ import eu.dotshell.pelo.platform.StringProvider
 
 @Composable
 fun SearchConnectionBadge(lineName: String, sizeDp: Int = 30) {
-    val drawableName = LineIconResolver.getDrawableNameForLineName(lineName)
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
-    val stringProvider = StringProvider(LocalPlatformContext.current)
+    // One of these per connection per search result, so allocating the providers and re-resolving
+    // the icon name on every recomposition happened across the whole visible list at once.
+    val context = LocalPlatformContext.current
+    val drawableProvider = remember(context) { DrawableProvider(context) }
+    val stringProvider = remember(context) { StringProvider(context) }
+    val drawableName = remember(lineName) { LineIconResolver.getDrawableNameForLineName(lineName) }
 
     if (drawableName.isNotBlank() && drawableProvider.hasDrawable(drawableName)) {
         Image(

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/search/bar/stops/StopSearchResultItem.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/components/search/bar/stops/StopSearchResultItem.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,7 +39,8 @@ fun StopSearchResultItem(
     onClick: () -> Unit,
     onOptionsClick: () -> Unit
 ) {
-    val strings = StringProvider(LocalPlatformContext.current)
+    val context = LocalPlatformContext.current
+    val strings = remember(context) { StringProvider(context) }
     ListItem(
         headlineContent = {
             Column(modifier = Modifier.padding(horizontal = 24.dp)) {
@@ -53,7 +55,11 @@ fun StopSearchResultItem(
                 val lineRules = provideTransportLineRules()
                 if (result.lines.isNotEmpty()) {
                     Spacer(modifier = Modifier.size(4.dp))
-                    val (strongLines, weakLines) = result.lines.partition { lineRules.isStrongLine(it) }
+                    // Runs once per result row, not once per recomposition of it: isStrongLine
+                    // normalises each name, and this is on the scroll path of the results list.
+                    val (strongLines, weakLines) = remember(result.lines, lineRules) {
+                        result.lines.partition { lineRules.isStrongLine(it) }
+                    }
                     if (strongLines.isNotEmpty()) {
                         Row(
                             horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/onboarding/TermsConsentGate.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/onboarding/TermsConsentGate.kt
@@ -15,10 +15,16 @@ import eu.dotshell.pelo.platform.LocalPlatformContext
  * [onConsentSatisfied] fires once when the app proceeds past the gate — either right after the
  * user accepts, or immediately on launch for a returning user who already accepted. It's the hook
  * platforms use to defer follow-up prompts (e.g. the location permission request) until consent.
+ *
+ * [onConsentScreenShown] fires instead when the gate puts its own screen up. Without it, a very
+ * first launch held the launch screen for the full timeout: the "we have something to draw" signal
+ * lives inside [content], which this branch never composes, so the consent screen sat invisible
+ * underneath until the platform gave up waiting.
  */
 @Composable
 fun TermsConsentGate(
     onConsentSatisfied: () -> Unit = {},
+    onConsentScreenShown: () -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val context = LocalPlatformContext.current
@@ -30,6 +36,7 @@ fun TermsConsentGate(
     val needsAcceptance = !state.accepted || (state.versionAccepted ?: 0) < config.version
 
     if (needsAcceptance) {
+        LaunchedEffect(Unit) { onConsentScreenShown() }
         TermsConsentScreen(
             consent = config,
             legalSections = legalSections,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/AllSchedulesSheetContent.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/AllSchedulesSheetContent.kt
@@ -55,14 +55,22 @@ private fun getLineColor(lineName: String): Color {
     return Color(LineColorHelper.getColorForLineString(lineName))
 }
 
-private fun getAllDayScheduleColor(hour: String, minute: String, defaultColor: Color): Color {
+/**
+ * [nowMinutes] is passed in rather than read here: this is called once per displayed minute, so a
+ * busy hour is fifteen to twenty calls and a screenful four or five hours' worth. Reading the clock
+ * inside meant that many instant-to-local-datetime conversions on every recomposition.
+ */
+private fun getAllDayScheduleColor(
+    hour: String,
+    minute: String,
+    defaultColor: Color,
+    nowMinutes: Int
+): Color {
     val hourInt = hour.toIntOrNull() ?: return defaultColor
     val minuteInt = minute.toIntOrNull() ?: return defaultColor
     // Hours 24+ are GTFS service-day times of after-midnight runs (night lines)
     if (hourInt !in 0..47 || minuteInt !in 0..59) return defaultColor
 
-    val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-    val nowMinutes = now.hour * 60 + now.minute
     val scheduleMinutes = hourInt * 60 + minuteInt
     val diffMinutes = scheduleMinutes - nowMinutes
 
@@ -189,7 +197,13 @@ fun AllSchedulesSheetContent(
             Spacer(modifier = Modifier.height(16.dp))
         }
 
-        val list = groupedSchedules.entries.toList()
+        val list = remember(groupedSchedules) { groupedSchedules.entries.toList() }
+        // One clock read for the whole sheet instead of one per minute cell.
+        val nowMinutes = remember(groupedSchedules) {
+            val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+            now.hour * 60 + now.minute
+        }
+        val lineColor = getLineColor(allSchedulesInfo.lineName)
 
         LazyColumn(
             modifier = Modifier
@@ -210,7 +224,7 @@ fun AllSchedulesSheetContent(
                         text = "${displayHour}h",
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                        color = getLineColor(allSchedulesInfo.lineName),
+                        color = lineColor,
                         modifier = Modifier.width(50.dp)
                     )
 
@@ -220,7 +234,12 @@ fun AllSchedulesSheetContent(
                         verticalArrangement = Arrangement.spacedBy(4.dp)
                     ) {
                         minutesList.forEach { minute ->
-                            val minuteColor = getAllDayScheduleColor(hour, minute, MaterialTheme.colorScheme.onSurface)
+                            val minuteColor = getAllDayScheduleColor(
+                                hour,
+                                minute,
+                                MaterialTheme.colorScheme.onSurface,
+                                nowMinutes
+                            )
                             Text(
                                 text = minute,
                                 style = MaterialTheme.typography.bodyLarge,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/LineDetailsBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/LineDetailsBottomSheet.kt
@@ -1023,8 +1023,12 @@ private fun ConnectionBadge(
     size: Dp = 32.dp,
     onClick: (() -> Unit)? = null
 ) {
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
-    val strings = StringProvider(LocalPlatformContext.current)
+    // One of these per connection of every stop in the list. The provider used to be rebuilt on
+    // each recomposition, which also meant the remember below keyed on a value that always
+    // changed — so hasDrawable was recomputed every time too.
+    val context = LocalPlatformContext.current
+    val drawableProvider = remember(context) { DrawableProvider(context) }
+    val strings = remember(context) { StringProvider(context) }
     val drawableName = remember(lineName) {
         LineIconResolver.getDrawableNameForLineName(lineName)
     }

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/LinesBottomSheet.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/LinesBottomSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -55,7 +56,13 @@ import eu.dotshell.pelo.platform.DrawableProvider
 import eu.dotshell.pelo.platform.LocalPlatformContext
 import eu.dotshell.pelo.platform.StringProvider
 
-/** One LazyColumn row: a category title, or a single row of chips inside a category. */
+/**
+ * One LazyColumn row: a category title, or a single row of chips inside a category.
+ *
+ * @Immutable for ChipRow's list of lines; without it the chip row could not skip while scrolling,
+ * which is the one thing this sheet is measured on.
+ */
+@Immutable
 private sealed interface LinesListItem {
     data class Header(val categoryId: String) : LinesListItem
     data class ChipRow(

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/LinesCatalog.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/LinesCatalog.kt
@@ -14,6 +14,7 @@ import eu.dotshell.pelo.platform.DrawableProvider
 import eu.dotshell.pelo.platform.LocalPlatformContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import androidx.compose.runtime.Immutable
 import org.jetbrains.compose.resources.DrawableResource
 
 /**
@@ -21,6 +22,7 @@ import org.jetbrains.compose.resources.DrawableResource
  * lookup work. [icon] is null when the line has no dedicated drawable (coloured fallback badge),
  * and [alertKey] is the pre-uppercased key used against the traffic-alert map.
  */
+@Immutable
 data class LineEntry(
     val name: String,
     val icon: DrawableResource?,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/NavigationModeState.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/NavigationModeState.kt
@@ -1,5 +1,6 @@
 package eu.dotshell.pelo.generic.ui.screens.plan
 
+import androidx.compose.runtime.Immutable
 import eu.dotshell.pelo.generic.data.repository.itinerary.itinerary.JourneyLeg
 import eu.dotshell.pelo.generic.data.repository.itinerary.itinerary.JourneyResult
 import eu.dotshell.pelo.generic.service.NavigationSession
@@ -19,6 +20,7 @@ private const val REROUTE_PROMPT_AFTER_SECONDS = 25
  * wording out of here is what lets the overlay translate it — the previous version hard-coded
  * French sentences into the state, so an English device got a half-translated screen.
  */
+@Immutable
 sealed interface NavigationInstruction {
 
     /** Walk to [stopName]; [distanceMeters] is null until a fix says how far it is. */
@@ -43,6 +45,12 @@ sealed interface NavigationInstruction {
     data object InProgress : NavigationInstruction
 }
 
+/**
+ * @Immutable so the overlay can skip. Every property is a val; the type was inferred unstable only
+ * through its four JourneyLeg fields and the instruction. Note that guidance republishes a whole
+ * new instance every second — which is exactly the contract: a new value, not a mutated one.
+ */
+@Immutable
 data class NavigationModeUiState(
     val currentLeg: JourneyLeg?,
     /** The leg whose line badge is shown — the ride in progress, or the one being walked to. */

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/itinerary/InlineItinerarySheetContent.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/itinerary/InlineItinerarySheetContent.kt
@@ -664,7 +664,7 @@ fun InlineItinerarySheetContent(
                 // Show extra large line icons on the left when a journey is selected.
                 // Weighted + wrapping: the close button is measured first and keeps its normal
                 // size; the badge strip flows onto extra lines when the journey has many legs
-                val drawableProvider = DrawableProvider(context)
+                val drawableProvider = remember(context) { DrawableProvider(context) }
                 FlowRow(
                     modifier = Modifier.weight(1f).padding(end = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(2.dp),

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/itinerary/ItineraryScreen.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/itinerary/ItineraryScreen.kt
@@ -621,20 +621,21 @@ fun JourneyDetailsSheetContent(
         }
 
         val sheetBgColor = if (useLightColors) SecondaryColor else PrimaryColor
+        val startActionScrim = remember(sheetBgColor) {
+            Brush.verticalGradient(
+                colors = listOf(
+                    Color.Transparent,
+                    sheetBgColor.copy(alpha = 0.85f),
+                    sheetBgColor,
+                    sheetBgColor
+                )
+            )
+        }
         if (showStartAction) Box(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .background(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color.Transparent,
-                            sheetBgColor.copy(alpha = 0.85f),
-                            sheetBgColor,
-                            sheetBgColor
-                        )
-                    )
-                )
+                .background(brush = startActionScrim)
                 .padding(horizontal = 16.dp, vertical = 16.dp)
         ) {
             Row(

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/itinerary/ItineraryScreen.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/plan/itinerary/ItineraryScreen.kt
@@ -105,7 +105,8 @@ fun CompactJourneyCard(
     showAvoidedAlertsBadge: Boolean = false,
     avoidedAlertsLabel: String? = null
 ) {
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
+    val platformContext = LocalPlatformContext.current
+    val drawableProvider = remember(platformContext) { DrawableProvider(platformContext) }
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val primaryTextColor = remember(useLightColors) {
@@ -320,8 +321,9 @@ private fun JourneyLegItem(
     isLast: Boolean,
     useLightColors: Boolean
 ) {
-    val drawableProvider = DrawableProvider(LocalPlatformContext.current)
-    val strings = StringProvider(LocalPlatformContext.current)
+    val platformContext = LocalPlatformContext.current
+    val drawableProvider = remember(platformContext) { DrawableProvider(platformContext) }
+    val strings = remember(platformContext) { StringProvider(platformContext) }
     val walkingLegColor = if (useLightColors) PrimaryColor else SecondaryColor
     val lineColor = remember(leg.isWalking, leg.routeName, walkingLegColor) {
         if (leg.isWalking) walkingLegColor else Color(

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/settings/SettingsScreen.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/screens/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -58,8 +59,10 @@ import eu.dotshell.pelo.platform.DrawableProvider
 import eu.dotshell.pelo.platform.FileSystem
 import eu.dotshell.pelo.platform.LocalPlatformContext
 import eu.dotshell.pelo.platform.StringProvider
+import eu.dotshell.pelo.platform.ioDispatcher
 import androidx.compose.material3.MaterialTheme
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -99,12 +102,22 @@ fun SettingsScreen(
     val validUntilTemplate = strings["timetable_data_valid_until"]
     val expiringTemplate = strings["timetable_data_expiring"]
     val expiredTemplate = strings["timetable_data_expired"]
-    val timetableDataSubtitle: String? = remember(platformContext, monthNames) {
-        val info = DatasetInfoLoader.load(FileSystem(platformContext))
-        val endDate = DatasetFreshness.parseIsoDate(info?.validity?.endDate)
-        if (endDate == null) {
-            null
-        } else {
+    // Off the composition thread: the first call opens dataset.json (asset or downloaded copy)
+    // and parses it. DatasetInfoLoader memoises afterwards, so this costs once per process — but
+    // once on the main thread is still once too many. The row stays hidden until the value lands,
+    // which is what it already did whenever there was no usable end date.
+    val timetableDataSubtitle: String? by produceState<String?>(
+        initialValue = null,
+        platformContext,
+        monthNames,
+        validUntilTemplate,
+        expiringTemplate,
+        expiredTemplate
+    ) {
+        value = withContext(ioDispatcher) {
+            val info = DatasetInfoLoader.load(FileSystem(platformContext))
+            val endDate = DatasetFreshness.parseIsoDate(info?.validity?.endDate)
+                ?: return@withContext null
             val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
             val formatted = DatasetFreshness.formatLongDate(
                 endDate,

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
@@ -799,7 +799,7 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
     override suspend fun searchAddresses(query: String): List<AddressSearchResult> =
         GeocodingRepository.getInstance().searchAddresses(query)
 
-    override fun searchLines(query: String): List<LineSearchResult> {
+    override suspend fun searchLines(query: String): List<LineSearchResult> {
         return schedulesRepository.searchLinesByName(query)
     }
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.datetime.plus
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -1317,9 +1318,25 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
         return eu.dotshell.pelo.generic.ui.viewmodel.normalizeStopName(stopName)
     }
 
-    override fun onCleared() {
+    /**
+     * Releases everything this view model started.
+     *
+     * Exists because the teardown path was otherwise unreachable: [onCleared] is `protected` and
+     * `ViewModel.clear()` is `internal`, so application code cannot call either, and nothing owns
+     * this view model through a ViewModelStoreOwner. `TransportViewModelHolder` keeps it for the
+     * life of the process, so in normal operation this runs only from tests — but a leak that
+     * cannot even be closed by hand is worse than one that can.
+     *
+     * Safe to call more than once: cancelling an already-cancelled job or scope is a no-op.
+     */
+    fun dispose() {
         vehiclePositionsJob?.cancel()
         globalLiveJob?.cancel()
+        viewModelScope.cancel()
+    }
+
+    override fun onCleared() {
+        dispose()
         super.onCleared()
     }
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
@@ -4,6 +4,7 @@ import eu.dotshell.pelo.platform.ioDispatcher
 
 import androidx.lifecycle.ViewModel
 import eu.dotshell.pelo.platform.Log
+import eu.dotshell.pelo.platform.AppForegroundState
 import eu.dotshell.pelo.platform.PlatformContext
 import eu.dotshell.pelo.platform.isUnmeteredNetwork
 import androidx.lifecycle.viewModelScope
@@ -100,6 +101,9 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
     }
     private var vehiclePositionsJob: Job? = null
     private var globalLiveJob: Job? = null
+
+    /** The line [startLiveTracking] was asked for, so a backgrounded stream can be put back. */
+    private var trackedLineName: String? = null
     private val favoritesRepository = FavoritesRepository(context)
     val raptorRepository = RaptorRepository.getInstance(context)
     val offlineDataManager = OfflineDataManager(transportApi, context)
@@ -226,6 +230,7 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
         // Load favorites first (synchronous SharedPrefs read, instant)
         loadFavorites()
         prefetchOfflineTiles()
+        observeForegroundForLiveStreams()
         // Fire all async loads in parallel — each launches its own coroutine
         loadTransportLines()
         loadStops()
@@ -1171,31 +1176,16 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
             stopGlobalLive()
         }
         vehiclePositionsJob?.cancel()
+        trackedLineName = lineName
         _isLiveTrackingEnabled.value = true
         _vehiclePositions.value = emptyList()
-
-        vehiclePositionsJob = viewModelScope.launch(ioDispatcher) {
-            // Not a per-line subscription: SIRI publishes the whole fleet on one stream and the
-            // service filters it. This second pass narrows by the app's own line-name rules,
-            // which normalise where the service compares literally.
-            vehiclePositionsRepository.streamVehiclePositionsByLine(lineName.trim()).collect { result ->
-                result.onSuccess { allPositions ->
-                    val requested = lineName.trim()
-                    val requestedNormalized = lineRules.normalizeForComparison(requested)
-
-                    _vehiclePositions.value = allPositions.filter {
-                        lineRules.normalizeForComparison(it.lineName) == requestedNormalized
-                    }
-                }.onFailure {
-                    Log.w("TransportViewModel", "Vehicle live stream error: ${it.message}")
-                }
-            }
-        }
+        vehiclePositionsJob = launchLineStream(lineName)
     }
 
     override fun stopLiveTracking() {
         vehiclePositionsJob?.cancel()
         vehiclePositionsJob = null
+        trackedLineName = null
         _isLiveTrackingEnabled.value = false
         _vehiclePositions.value = emptyList()
     }
@@ -1218,15 +1208,69 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
         }
         _isGlobalLiveEnabled.value = true
         _globalVehiclePositions.value = emptyList()
+        globalLiveJob = launchGlobalStream()
+    }
 
-        globalLiveJob = viewModelScope.launch(ioDispatcher) {
-            vehiclePositionsRepository.streamAllVehiclePositions().collect { result ->
-                result.onSuccess { allPositions ->
-                    _globalVehiclePositions.value = allPositions
-                }.onFailure {
-                    Log.w("TransportViewModel", "Global live stream error: ${it.message}")
+    private fun launchLineStream(lineName: String): Job = viewModelScope.launch(ioDispatcher) {
+        // Not a per-line subscription: SIRI publishes the whole fleet on one stream and the
+        // service filters it. This second pass narrows by the app's own line-name rules,
+        // which normalise where the service compares literally.
+        val requestedNormalized = lineRules.normalizeForComparison(lineName.trim())
+        vehiclePositionsRepository.streamVehiclePositionsByLine(lineName.trim()).collect { result ->
+            result.onSuccess { allPositions ->
+                _vehiclePositions.value = allPositions.filter {
+                    lineRules.normalizeForComparison(it.lineName) == requestedNormalized
                 }
+            }.onFailure {
+                Log.w("TransportViewModel", "Vehicle live stream error: ${it.message}")
             }
+        }
+    }
+
+    private fun launchGlobalStream(): Job = viewModelScope.launch(ioDispatcher) {
+        vehiclePositionsRepository.streamAllVehiclePositions().collect { result ->
+            result.onSuccess { allPositions ->
+                _globalVehiclePositions.value = allPositions
+            }.onFailure {
+                Log.w("TransportViewModel", "Global live stream error: ${it.message}")
+            }
+        }
+    }
+
+    /**
+     * Drops the vehicle streams while the app is not in front of the user, and puts back whichever
+     * was running when it returns.
+     *
+     * The enabled flags are left alone throughout: they carry the user's choice, and the map must
+     * still read as "live" when they come back. Only the subscriptions go. The last positions are
+     * kept too — they are what the map is currently drawing, and the first push after resuming
+     * replaces them.
+     *
+     * Nothing here fires on a screen change: this is app-wide foreground, so moving between the
+     * map and settings does not disturb the stream.
+     */
+    private fun observeForegroundForLiveStreams() {
+        AppForegroundState.start(context)
+        viewModelScope.launch {
+            AppForegroundState.isForeground.collect { foreground ->
+                if (foreground) resumeLiveStreams() else suspendLiveStreams()
+            }
+        }
+    }
+
+    private fun suspendLiveStreams() {
+        vehiclePositionsJob?.cancel()
+        vehiclePositionsJob = null
+        globalLiveJob?.cancel()
+        globalLiveJob = null
+    }
+
+    private fun resumeLiveStreams() {
+        if (_isLiveTrackingEnabled.value && vehiclePositionsJob == null) {
+            trackedLineName?.let { vehiclePositionsJob = launchLineStream(it) }
+        }
+        if (_isGlobalLiveEnabled.value && globalLiveJob == null) {
+            globalLiveJob = launchGlobalStream()
         }
     }
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
@@ -5,6 +5,7 @@ import eu.dotshell.pelo.platform.ioDispatcher
 import androidx.lifecycle.ViewModel
 import eu.dotshell.pelo.platform.Log
 import eu.dotshell.pelo.platform.PlatformContext
+import eu.dotshell.pelo.platform.isUnmeteredNetwork
 import androidx.lifecycle.viewModelScope
 import eu.dotshell.pelo.generic.data.models.stops.Favorite
 import eu.dotshell.pelo.generic.data.models.realtime.vehiclepositions.SimpleVehiclePosition
@@ -43,6 +44,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.plus
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -63,6 +65,12 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
         private const val TAG = "TransportViewModel"
         // Set to false for production builds to skip string formatting overhead in hot paths
         private const val DEBUG_LOGGING = false
+
+        /**
+         * How long the offline tile prefetch waits before starting, so it competes with neither
+         * the first frame nor the initial line/stop/alert loads.
+         */
+        private const val OFFLINE_PREFETCH_DELAY_MS = 30_000L
     }
 
     private val transportApi: TransportApi = TransportServiceProvider.getTransportApi()
@@ -190,31 +198,50 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
     init {
         // Load favorites first (synchronous SharedPrefs read, instant)
         loadFavorites()
-        viewModelScope.launch(ioDispatcher) {
-            while (true) {
-                offlineDataManager.refreshOfflineDataInfo()
-                val info = offlineDataManager.offlineDataInfo.value
-                if (!info.isAvailable) {
-                    try {
-                        offlineDataManager.downloadAllOfflineData()
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Auto-download failed: ${e.message}")
-                    }
-                }
-                
-                offlineDataManager.refreshOfflineDataInfo()
-                if (offlineDataManager.offlineDataInfo.value.isAvailable) {
-                    break // Download succeeded or was already available
-                }
-                
-                // Retry every 5 minutes if it failed
-                kotlinx.coroutines.delay(5 * 60 * 1000L)
-            }
-        }
+        prefetchOfflineTiles()
         // Fire all async loads in parallel — each launches its own coroutine
         loadTransportLines()
         loadStops()
         loadTrafficAlerts()
+    }
+
+    /**
+     * Pulls the offline map tiles once, in the background, and only over a network that is free
+     * to use.
+     *
+     * This used to be a `while (true)` that fired the instant the view model was built and retried
+     * every five minutes. Three things were wrong with that. `OfflineDataInfo.isAvailable` is just
+     * `downloadedMapStyles.isNotEmpty()`, so it is false on every fresh install — meaning hundreds
+     * of megabytes of tiles left on whatever connection was to hand, nobody having asked. The
+     * download then competed with the first frame for the network and the disk. And a device that
+     * never reaches an unmetered network retried for as long as the app stayed open.
+     *
+     * The info refresh stays unconditional: the map style picker reads
+     * `offlineDataInfo.downloadedMapStyles` to know which styles work offline, whether or not
+     * anything is downloading today. Only the download itself is gated.
+     *
+     * On iOS this never runs: `isUnmeteredNetwork` is hardcoded to false there, because a real
+     * check needs NWPathMonitor and reports asynchronously.
+     */
+    private fun prefetchOfflineTiles() {
+        viewModelScope.launch(ioDispatcher) {
+            offlineDataManager.refreshOfflineDataInfo()
+            if (offlineDataManager.offlineDataInfo.value.isAvailable) return@launch
+            if (!isUnmeteredNetwork(context)) {
+                Log.i(TAG, "Offline tiles: skipped, network is metered or unknown")
+                return@launch
+            }
+            // Let the map, the lines and the first interactions have the device to themselves.
+            kotlinx.coroutines.delay(OFFLINE_PREFETCH_DELAY_MS)
+            try {
+                offlineDataManager.downloadAllOfflineData()
+            } catch (e: CancellationException) {
+                // Shutting down, not failing: let it propagate or the scope never finishes closing.
+                throw e
+            } catch (e: Exception) {
+                Log.w(TAG, "Offline tiles: prefetch failed: ${e.message}")
+            }
+        }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
@@ -100,7 +100,7 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
     private val favoritesRepository = FavoritesRepository(context)
     val raptorRepository = RaptorRepository.getInstance(context)
     val offlineDataManager = OfflineDataManager(transportApi, context)
-    private val transportCache by lazy { eu.dotshell.pelo.generic.data.cache.TransportCacheImpl(context) }
+    private val transportCache by lazy { eu.dotshell.pelo.generic.data.cache.TransportCacheImpl.getInstance(context) }
     private val offlineRepository by lazy { eu.dotshell.pelo.generic.data.offline.OfflineRepository(context) }
     private val _linesState = MutableStateFlow<TransportLinesState>(TransportLinesState.Loading)
 

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModel.kt
@@ -50,9 +50,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -134,6 +137,29 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
 
     private val _isGlobalLiveEnabled = MutableStateFlow(false)
     override val isGlobalLiveEnabled: StateFlow<Boolean> = _isGlobalLiveEnabled.asStateFlow()
+
+    /**
+     * Whether the live layer currently has anything to show.
+     *
+     * PlanContent subscribed to both position lists purely to reach this one boolean, so every SSE
+     * push recomposed that whole subtree with the entire fleet in hand. Derived here instead, the
+     * lists stay subscribed only where they are actually drawn.
+     *
+     * Declared after the four flows it combines: these are property initialisers, so referring to
+     * one before its declaration leaves it null at construction time.
+     */
+    override val hasActiveVehicles: StateFlow<Boolean> = combine(
+        _isLiveTrackingEnabled,
+        _isGlobalLiveEnabled,
+        _vehiclePositions,
+        _globalVehiclePositions
+    ) { liveTracking, globalLive, positions, globalPositions ->
+        when {
+            liveTracking -> positions.isNotEmpty()
+            globalLive -> globalPositions.isNotEmpty()
+            else -> false
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
     // Toggle to draw every line trace on the map (not only the strong ones),
     // mirroring the global-live button behaviour: on until tapped again.
@@ -1148,9 +1174,10 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
         _isLiveTrackingEnabled.value = true
         _vehiclePositions.value = emptyList()
 
-        vehiclePositionsJob = viewModelScope.launch {
-            // Focused per-line stream (one request per poll); the filter stays
-            // as a safety net in case the backend returns more than the asked line.
+        vehiclePositionsJob = viewModelScope.launch(ioDispatcher) {
+            // Not a per-line subscription: SIRI publishes the whole fleet on one stream and the
+            // service filters it. This second pass narrows by the app's own line-name rules,
+            // which normalise where the service compares literally.
             vehiclePositionsRepository.streamVehiclePositionsByLine(lineName.trim()).collect { result ->
                 result.onSuccess { allPositions ->
                     val requested = lineName.trim()
@@ -1192,7 +1219,7 @@ class TransportViewModel(private val context: PlatformContext) : ViewModel(), Tr
         _isGlobalLiveEnabled.value = true
         _globalVehiclePositions.value = emptyList()
 
-        globalLiveJob = viewModelScope.launch {
+        globalLiveJob = viewModelScope.launch(ioDispatcher) {
             vehiclePositionsRepository.streamAllVehiclePositions().collect { result ->
                 result.onSuccess { allPositions ->
                     _globalVehiclePositions.value = allPositions

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModelHolder.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModelHolder.kt
@@ -1,0 +1,37 @@
+package eu.dotshell.pelo.generic.ui.viewmodel
+
+import eu.dotshell.pelo.platform.PlatformContext
+import eu.dotshell.pelo.platform.applicationContextOf
+import kotlin.concurrent.Volatile
+
+/**
+ * Hands out the one [TransportViewModel] the app uses.
+ *
+ * It used to be built by hand inside a `LaunchedEffect` in `App` and parked in a `remember`, which
+ * meant it was attached to no ViewModelStoreOwner at all: `onCleared` never ran, `viewModelScope`
+ * was never cancelled, and it retained whichever Activity was current when it was built. Every
+ * Activity recreation then built a second one — and a system dark-mode switch is enough to trigger
+ * that, since the manifest does not list `uiMode` in `configChanges` — while the first kept its
+ * coroutines, its SSE subscription and its caches alive against an Activity that no longer existed.
+ *
+ * So it is scoped to the process instead, exactly like `RaptorRepository`, `SchedulesRepository`
+ * and `JourneyCache` already are, and built on the application context so no Activity can be
+ * pinned through it.
+ *
+ * Deliberately never disposed from composition: tearing the view model down on every rotation is
+ * the failure this replaces. [TransportViewModel.dispose] exists for tests and for any future
+ * owner that genuinely scopes it.
+ */
+object TransportViewModelHolder {
+
+    @Volatile
+    private var instance: TransportViewModel? = null
+
+    /**
+     * No `synchronized` in commonMain — a @Volatile double-check is enough for a startup
+     * singleton, matching the repositories named above. A lost race only builds one extra
+     * instance, which is discarded immediately.
+     */
+    fun getOrCreate(context: PlatformContext): TransportViewModel =
+        instance ?: TransportViewModel(applicationContextOf(context)).also { instance = it }
+}

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModelInterface.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModelInterface.kt
@@ -27,6 +27,13 @@ interface TransportViewModelInterface {
     val isOffline: StateFlow<Boolean>
     val isGlobalLiveEnabled: StateFlow<Boolean>
     val globalVehiclePositions: StateFlow<List<SimpleVehiclePosition>>
+
+    /**
+     * Whether the live layer has anything to show, for callers that need the fact but not the
+     * fleet — subscribing to the position lists just to test isNotEmpty() means recomposing on
+     * every SSE push.
+     */
+    val hasActiveVehicles: StateFlow<Boolean>
     val headsigns: StateFlow<Map<Int, String>>
     val availableDirections: StateFlow<List<Int>>
     val allSchedules: StateFlow<List<String>>

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModelInterface.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/ui/viewmodel/TransportViewModelInterface.kt
@@ -47,7 +47,7 @@ interface TransportViewModelInterface {
 
     suspend fun searchStops(query: String): List<StationSearchResult>
     suspend fun searchAddresses(query: String): List<AddressSearchResult>
-    fun searchLines(query: String): List<LineSearchResult>
+    suspend fun searchLines(query: String): List<LineSearchResult>
 
     fun loadAllLines()
     fun preloadStops()

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/utils/date/HolidayDetector.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/generic/utils/date/HolidayDetector.kt
@@ -5,6 +5,7 @@ import eu.dotshell.pelo.platform.FileSystem
 import eu.dotshell.pelo.platform.PlatformContext
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
+import kotlin.concurrent.Volatile
 import kotlinx.datetime.plus
 import kotlinx.serialization.json.Json
 
@@ -22,10 +23,10 @@ class HolidayDetector(
     private val schoolHolidays: List<HolidayPeriod> = loadSchoolHolidays()
 
     private fun loadSchoolHolidays(): List<HolidayPeriod> {
+        cachedPeriods[holidayFileName]?.let { return it }
         return try {
             val json = fileSystem.readAsset(holidayFileName)
-            val jsonConfig = Json { ignoreUnknownKeys = true }
-            val holidaysData = jsonConfig.decodeFromString<HolidaysData>(json)
+            val holidaysData = JSON.decodeFromString<HolidaysData>(json)
             holidaysData.holidays.mapNotNull { holiday ->
                 val startDate = try {
                     LocalDate.parse(holiday.startDateInclusive)
@@ -47,10 +48,26 @@ class HolidayDetector(
                         endDate = endDate ?: startDate.plus(2, DateTimeUnit.MONTH)
                     )
                 } else null
-            }
+            }.also { cachedPeriods = cachedPeriods + (holidayFileName to it) }
         } catch (e: Exception) {
             emptyList()
         }
+    }
+
+    companion object {
+        private val JSON = Json { ignoreUnknownKeys = true }
+
+        /**
+         * Parsed periods per asset name. The bundled holidays file cannot change while the process
+         * runs, and two detectors are built per process (one by RaptorRepository, one by the view
+         * model), so without this the asset was read and parsed twice. The Json instance was also
+         * being constructed inside the parse rather than reused.
+         *
+         * Copy-on-write: replaced, never mutated, so a reader cannot see it half-built. A lost
+         * race just parses twice, which is what already happened.
+         */
+        @Volatile
+        private var cachedPeriods: Map<String, List<HolidayPeriod>> = emptyMap()
     }
 
     /**

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/platform/AppForegroundState.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/platform/AppForegroundState.kt
@@ -1,0 +1,24 @@
+package eu.dotshell.pelo.platform
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Whether the app is in front of the user, app-wide rather than per-screen.
+ *
+ * Exists so long-lived streams can stand down while nobody is looking at them. The vehicle
+ * positions feed is the motivating case: it is a server-sent event stream that pushes the whole
+ * fleet, and it used to stay open for as long as the process lived.
+ *
+ * Starts as `true`. On both platforms the signal only arrives on a transition, so assuming the
+ * foreground until told otherwise keeps a stream running that is already running, rather than
+ * silently withholding one that should be live.
+ */
+expect object AppForegroundState {
+
+    val isForeground: StateFlow<Boolean>
+
+    /**
+     * Begins observing. Idempotent — later calls do nothing — so callers need not coordinate.
+     */
+    fun start(context: PlatformContext)
+}

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/platform/Platform.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/platform/Platform.kt
@@ -37,3 +37,12 @@ expect fun exportFile(context: PlatformContext, filename: String, content: Strin
  * Conservative: when connectivity cannot be determined, returns false.
  */
 expect fun isUnmeteredNetwork(context: PlatformContext): Boolean
+
+/**
+ * The process-scoped context behind [context]. Android returns `applicationContext`, so anything
+ * held for the life of the process cannot pin the Activity that happened to create it; iOS has no
+ * such distinction and returns [context] unchanged.
+ *
+ * Use this whenever a singleton stores a context — see `TransportViewModelHolder`.
+ */
+expect fun applicationContextOf(context: PlatformContext): PlatformContext

--- a/shared/src/commonMain/kotlin/eu/dotshell/pelo/platform/Resources.kt
+++ b/shared/src/commonMain/kotlin/eu/dotshell/pelo/platform/Resources.kt
@@ -1,6 +1,7 @@
 package eu.dotshell.pelo.platform
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.painter.Painter
 import eu.dotshell.pelo.resources.Res
 import eu.dotshell.pelo.resources.allDrawableResources
@@ -15,7 +16,12 @@ import org.jetbrains.compose.resources.stringResource
  * (`composeResources/drawable`). Resources are resolved dynamically by name via
  * the generated [Res.allDrawableResources] registry, so the same name-based API
  * used across the UI works unchanged on every platform (was Android `getIdentifier`).
+ *
+ * Carries no state — see [equals]. The [context] parameter is vestigial, left from the days when
+ * lookup went through Android's `getIdentifier`; removing it would touch every call site, so it
+ * stays for now.
  */
+@Immutable
 @OptIn(ExperimentalResourceApi::class)
 class DrawableProvider(@Suppress("unused") private val context: PlatformContext) {
 
@@ -31,7 +37,22 @@ class DrawableProvider(@Suppress("unused") private val context: PlatformContext)
     fun hasDrawable(name: String): Boolean =
         Res.allDrawableResources.containsKey(name)
 
+    /**
+     * All instances are interchangeable: every lookup goes to the same generated registry and the
+     * context is unused.
+     *
+     * This is what actually restores skipping. @Immutable alone would not: Compose still asks
+     * `equals` whether a parameter changed, so with identity equality a freshly built provider
+     * always read as "changed" — and one is passed down into PlanContent, which meant that entire
+     * subtree could never skip a recomposition.
+     */
+    override fun equals(other: Any?): Boolean = other is DrawableProvider
+
+    override fun hashCode(): Int = DRAWABLE_PROVIDER_HASH
+
     companion object {
+        private const val DRAWABLE_PROVIDER_HASH = 0x11D0C0DE
+
         /**
          * Name lookup that needs neither a context nor a composition, so screens can resolve
          * their icons once on a background thread instead of once per chip per recomposition.
@@ -44,9 +65,20 @@ class DrawableProvider(@Suppress("unused") private val context: PlatformContext)
 /**
  * Cross-platform string access backed by Compose Multiplatform resources
  * (`composeResources/values`), resolved dynamically by name.
+ *
+ * Stateless and interchangeable, for the same reasons as [DrawableProvider].
  */
+@Immutable
 @OptIn(ExperimentalResourceApi::class)
 class StringProvider(@Suppress("unused") private val context: PlatformContext) {
+
+    override fun equals(other: Any?): Boolean = other is StringProvider
+
+    override fun hashCode(): Int = STRING_PROVIDER_HASH
+
+    private companion object {
+        private const val STRING_PROVIDER_HASH = 0x5710C0DE
+    }
 
     @Composable
     operator fun get(name: String): String =

--- a/shared/src/iosMain/kotlin/eu/dotshell/pelo/platform/AppForegroundState.ios.kt
+++ b/shared/src/iosMain/kotlin/eu/dotshell/pelo/platform/AppForegroundState.ios.kt
@@ -1,0 +1,45 @@
+package eu.dotshell.pelo.platform
+
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationWillEnterForegroundNotification
+
+/**
+ * Backed by the UIKit application notifications, the same pair
+ * [eu.dotshell.pelo.generic.data.telemetry.TelemetryService] observes.
+ *
+ * The observers are never removed: this is a process-lifetime singleton, so there is no point at
+ * which removing them would be correct.
+ */
+actual object AppForegroundState {
+
+    private val _isForeground = MutableStateFlow(true)
+    actual val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
+
+    @Volatile
+    private var started = false
+
+    actual fun start(context: PlatformContext) {
+        if (started) return
+        started = true
+
+        NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIApplicationWillEnterForegroundNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue,
+            usingBlock = { _ -> _isForeground.value = true }
+        )
+
+        NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIApplicationDidEnterBackgroundNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue,
+            usingBlock = { _ -> _isForeground.value = false }
+        )
+    }
+}

--- a/shared/src/iosMain/kotlin/eu/dotshell/pelo/platform/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/eu/dotshell/pelo/platform/Platform.ios.kt
@@ -22,6 +22,9 @@ actual fun appVersionName(context: PlatformContext): String =
 // feature is effectively off on iOS, matching its currently unverified status.
 actual fun isUnmeteredNetwork(context: PlatformContext): Boolean = false
 
+// iOS has no Activity/Application split — the context is already process-wide.
+actual fun applicationContextOf(context: PlatformContext): PlatformContext = context
+
 actual val ioDispatcher: CoroutineDispatcher = Dispatchers.Default
 
 actual fun exportFile(context: PlatformContext, filename: String, content: String) {


### PR DESCRIPTION
This pull request introduces several improvements focused on background initialization, process lifecycle handling, and code robustness across the Android and shared codebases. The main themes are safer and more independent app startup routines, more reliable service teardown, and enhanced profiling and platform support.

**Background initialization and process lifecycle:**

* Refactored `PeloApplication`'s background initialization to launch each major step (asset verification, transport service provider init, traffic alert scheduling, telemetry setup) in its own coroutine using a `SupervisorJob`, ensuring that failure in one does not prevent others from running and that exceptions are logged. [[1]](diffhunk://#diff-5fb765824cf163a7d612a271229fb8f4319e4d04afd1154519ddb755eb919b58L25-R29) [[2]](diffhunk://#diff-5fb765824cf163a7d612a271229fb8f4319e4d04afd1154519ddb755eb919b58L42-L53)
* Introduced an Android-specific implementation of `AppForegroundState` backed by `ProcessLifecycleOwner`, providing a reliable, process-wide foreground/background state for use throughout the app.

**Service teardown and background work:**

* Improved `NavigationModeForegroundService` teardown: added a dedicated `teardownScope` and a timeout (`TEARDOWN_GRACE_MS`) to ensure trip finalization has time to persist, preventing resource leaks and ensuring service shutdown is robust even if child coroutines hang. [[1]](diffhunk://#diff-e3cbf1e33003f53b92dbf47b82d37135e714099cf5d3a65d63bda12859512bcbR49-R55) [[2]](diffhunk://#diff-e3cbf1e33003f53b92dbf47b82d37135e714099cf5d3a65d63bda12859512bcbL99-R113) [[3]](diffhunk://#diff-e3cbf1e33003f53b92dbf47b82d37135e714099cf5d3a65d63bda12859512bcbR298-R300)
* Updated usage of `TransportCacheImpl` to consistently use its singleton instance, preventing redundant cache loading and ensuring a single cache is used across the app. [[1]](diffhunk://#diff-e81bec2ca77faa0e01c8de8d85e761a9ffa927b6fb3849e83c98d7fe3964808eR100-R103) [[2]](diffhunk://#diff-e3cbf1e33003f53b92dbf47b82d37135e714099cf5d3a65d63bda12859512bcbL183-R193)

**Profiling and ProGuard rules:**

* Enhanced the Baseline Profile generator to exercise more code paths (lines sheet, settings) and handle localization in tab selection, resulting in a more representative profile for AOT compilation and improved cold-start performance. [[1]](diffhunk://#diff-0c0488b3ab94d487bb3557cac7bd20ea459bda2a918e7415ca2a725a8a6c26c4L20-R40) [[2]](diffhunk://#diff-0c0488b3ab94d487bb3557cac7bd20ea459bda2a918e7415ca2a725a8a6c26c4L30-R98)
* Cleaned up and clarified ProGuard rules: removed obsolete Retrofit/Gson-specific rules, added comments, and narrowed keep rules for data models, setting the stage for future shrinking improvements.

**Platform support:**

* Added `applicationContextOf` to the Android platform implementation, providing a consistent way to obtain the application context from a `PlatformContext`.